### PR TITLE
Added basic project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode
+.vs
+build
+out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.20)
+
+
+project(etna)
+
+# Prevent the user from polluting the root directory with build files
+if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  message(
+    FATAL_ERROR
+      "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there."
+    )
+endif()
+
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+if (MSVC)
+    add_compile_options(/W3)
+else()
+    add_compile_options(-Wall -Wextra)
+endif()
+
+
+include("get_cpm.cmake")
+include("thirdparty.cmake")
+
+
+add_subdirectory(etna)

--- a/etna/CMakeLists.txt
+++ b/etna/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+
+
+add_library(etna
+	"source/UniqueImage.cpp"
+ "source/VmaImplementation.cpp")
+
+target_include_directories(etna PUBLIC include)
+target_include_directories(etna PRIVATE source)
+
+target_link_libraries(etna Vulkan::Vulkan VulkanMemoryAllocator StbLibraries)

--- a/etna/include/etna/UniqueImage.hpp
+++ b/etna/include/etna/UniqueImage.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+
+void printHelloWorld();

--- a/etna/source/UniqueImage.cpp
+++ b/etna/source/UniqueImage.cpp
@@ -1,0 +1,9 @@
+#include <etna/UniqueImage.hpp>
+
+#include <iostream>
+
+
+void printHelloWorld()
+{
+	std::cout << "Hello, world!\n";
+}

--- a/etna/source/VmaImplementation.cpp
+++ b/etna/source/VmaImplementation.cpp
@@ -1,0 +1,2 @@
+#define VMA_IMPLEMENTATION
+#include <vk_mem_alloc.h>

--- a/get_cpm.cmake
+++ b/get_cpm.cmake
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.20)
+
+
+set(CPM_DOWNLOAD_VERSION 0.34.0)
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+  file(DOWNLOAD
+       https://github.com/TheLartians/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION}
+  )
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})
+
+set(CPM_USE_LOCAL_PACKAGES True)

--- a/thirdparty.cmake
+++ b/thirdparty.cmake
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.20)
+
+
+find_package(Vulkan REQUIRED)
+
+CPMAddPackage(
+    NAME VulkanMemoryAllocator
+    GITHUB_REPOSITORY GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator
+    GIT_TAG master
+    DOWNLOAD_ONLY YES
+)
+
+if (VulkanMemoryAllocator_ADDED)
+    add_library(VulkanMemoryAllocator INTERFACE)
+    target_include_directories(VulkanMemoryAllocator INTERFACE ${VulkanMemoryAllocator_SOURCE_DIR}/include/)
+endif ()
+
+CPMAddPackage(
+    NAME StbLibraries
+    GITHUB_REPOSITORY nothings/stb
+    GIT_TAG master
+    DOWNLOAD_ONLY YES
+)
+
+if (StbLibraries_ADDED)
+    add_library(StbLibraries INTERFACE)
+    target_include_directories(StbLibraries INTERFACE ${StbLibraries_SOURCE_DIR}/)
+endif ()


### PR DESCRIPTION
Basic public include and private sources structure which is standard for librareis. Users shall include our headers as `<etna/UniqueImage.hpp>`.
Linked vulkan library to `etna` target.
Also added auto-download of CmakeCPM, which allows us to automagically fetch dependencies, such as VulkanMemoryAllocators and StbImage. Added those as well.
Sadly, as stb libraries and VMA do not provide proper cmake, targets had to be added manually in thirdparty.cmake. Libraries which provide proper modern (no more than 10 year old) cmakelists get integrated in a single line.