### PR TITLE
Implemented etna pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
 .vs
+.cache
 build
 out

--- a/etna/CMakeLists.txt
+++ b/etna/CMakeLists.txt
@@ -4,7 +4,8 @@ cmake_minimum_required(VERSION 3.20)
 add_library(etna
   "source/Image.cpp"
   "source/Buffer.cpp"
-  "source/GraphicsPipeline.cpp"
+  "source/PipelineBase.cpp"
+  "source/PipelineManager.cpp"
   "source/VmaImplementation.cpp"
   "source/ShaderProgram.cpp"
   "source/DescriptorSetLayout.cpp"

--- a/etna/CMakeLists.txt
+++ b/etna/CMakeLists.txt
@@ -4,12 +4,14 @@ cmake_minimum_required(VERSION 3.20)
 add_library(etna
   "source/Image.cpp"
   "source/Buffer.cpp"
+  "source/GraphicsPipeline.cpp"
   "source/VmaImplementation.cpp"
   "source/ShaderProgram.cpp"
   "source/DescriptorSetLayout.cpp"
   "source/GlobalContext.cpp"
   "source/DescriptorSet.cpp"
-  "source/VkHppDispatchLoaderStorage.cpp" "source/Etna.cpp")
+  "source/VkHppDispatchLoaderStorage.cpp"
+  "source/Etna.cpp")
 
 target_include_directories(etna PUBLIC include)
 target_include_directories(etna PRIVATE source)

--- a/etna/include/etna/Assert.hpp
+++ b/etna/include/etna/Assert.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef ETNA_UTIL_HPP_INCLUDED
-#define ETNA_UTIL_HPP_INCLUDED
+#ifndef ETNA_ASSERT_HPP_INCLUDED
+#define ETNA_ASSERT_HPP_INCLUDED
 
 #include <stdexcept>
 #include <spdlog/spdlog.h>
@@ -53,4 +53,4 @@ while (0)
 // Do NOT use in app code!
 #define ETNA_VULKAN_HPP_ASSERT_ON_RESULT(expr) ETNA_ASSERTF(expr, "{}", message)
 
-#endif
+#endif // ETNA_ASSERT_HPP_INCLUDED

--- a/etna/include/etna/Buffer.hpp
+++ b/etna/include/etna/Buffer.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ETNA_BUFFER_HPP_INCLUDED
+#define ETNA_BUFFER_HPP_INCLUDED
 
 #include <etna/Vulkan.hpp>
 #include <vk_mem_alloc.h>
@@ -45,3 +47,5 @@ private:
 };
 
 }
+
+#endif // ETNA_BUFFER_HPP_INCLUDED

--- a/etna/include/etna/DescriptorSet.hpp
+++ b/etna/include/etna/DescriptorSet.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef ETNA_UPDATE_DESCRIPTOR_SETS_HPP_INCLUDED
-#define ETNA_UPDATE_DESCRIPTOR_SETS_HPP_INCLUDED
+#ifndef ETNA_DESCRIPTOR_SET_HPP_INCLUDED
+#define ETNA_DESCRIPTOR_SET_HPP_INCLUDED
 
 #include <variant>
 #include <etna/Vulkan.hpp>
@@ -92,4 +92,4 @@ namespace etna
   void write_set(const DescriptorSet &dst, const vk::ArrayProxy<const Binding> &bindings);
 }
 
-#endif
+#endif // ETNA_DESCRIPTOR_SET_HPP_INCLUDED

--- a/etna/include/etna/DescriptorSetLayout.hpp
+++ b/etna/include/etna/DescriptorSetLayout.hpp
@@ -88,4 +88,5 @@ namespace etna
     std::vector<vk::DescriptorSetLayout> vkLayouts;
   };
 }
-#endif
+
+#endif // ETNA_DESCRIPTOR_SET_LAYOUT_HPP_INCLUDED

--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -55,4 +55,4 @@ namespace etna
 
 }
 
-#endif
+#endif // ETNA_ETNA_HPP_INCLUDED

--- a/etna/include/etna/EtnaConfig.hpp
+++ b/etna/include/etna/EtnaConfig.hpp
@@ -22,4 +22,4 @@ inline constexpr uint32_t ETNA_VERSION = VK_MAKE_VERSION(0, 1, 0);
 
 }
 
-#endif
+#endif // ETNA_ETNA_CONFIG_HPP_INCLUDED

--- a/etna/include/etna/Forward.hpp
+++ b/etna/include/etna/Forward.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef ETNA_FORWARD_HPP_INCLUDED
+#define ETNA_FORWARD_HPP_INCLUDED
+
+#include <cstdint>
+
+namespace etna
+{
+
+class PipelineManager;
+using PipelineId = std::uint32_t;
+inline constexpr PipelineId INVALID_PIPELINE_ID = static_cast<PipelineId>(-1);
+
+struct ShaderProgramManager;
+using ShaderProgramId = std::uint32_t;
+inline constexpr ShaderProgramId INVALID_SHADER_PROGRAM_ID = static_cast<PipelineId>(-1);
+
+}
+
+
+#endif // ETNA_FORWARD_HPP_INCLUDED

--- a/etna/include/etna/GlobalContext.hpp
+++ b/etna/include/etna/GlobalContext.hpp
@@ -5,6 +5,7 @@
 #include <etna/Vulkan.hpp>
 #include <etna/DescriptorSetLayout.hpp>
 #include <etna/ShaderProgram.hpp>
+#include <etna/PipelineManager.hpp>
 #include <etna/DescriptorSet.hpp>
 #include <etna/Image.hpp>
 #include <etna/Buffer.hpp>
@@ -32,6 +33,7 @@ namespace etna
     uint32_t getQueueFamilyIdx() const { return universalQueueFamilyIdx; }
 
     ShaderProgramManager &getShaderManager() { return shaderPrograms; }
+    PipelineManager &getPipelineManager() { return pipelineManager.value(); }
     DescriptorSetLayoutCache &getDescriptorSetLayouts() { return descriptorSetLayouts; }
     DynamicDescriptorPool &getDescriptorPool() { return *descriptorPool; }
 
@@ -53,6 +55,9 @@ namespace etna
 
     DescriptorSetLayoutCache descriptorSetLayouts {}; 
     ShaderProgramManager shaderPrograms {};
+
+    // Optionals for late init
+    std::optional<PipelineManager> pipelineManager;
     std::optional<DynamicDescriptorPool> descriptorPool;
   };
 

--- a/etna/include/etna/GlobalContext.hpp
+++ b/etna/include/etna/GlobalContext.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef ETNA_CONTEXT_HPP_INCLUDED
-#define ETNA_CONTEXT_HPP_INCLUDED
+#ifndef ETNA_GLOBAL_CONTEXT_HPP_INCLUDED
+#define ETNA_GLOBAL_CONTEXT_HPP_INCLUDED
 
 #include <etna/Vulkan.hpp>
 #include <etna/DescriptorSetLayout.hpp>
@@ -59,5 +59,4 @@ namespace etna
   GlobalContext &get_context();
 }
 
-
-#endif
+#endif // ETNA_GLOBAL_CONTEXT_HPP_INCLUDED

--- a/etna/include/etna/GraphicsPipeline.hpp
+++ b/etna/include/etna/GraphicsPipeline.hpp
@@ -5,7 +5,7 @@
 #include <etna/Vulkan.hpp>
 #include <etna/VertexInput.hpp>
 #include <etna/PipelineBase.hpp>
-
+#include <variant>
 
 namespace etna
 {
@@ -15,7 +15,10 @@ class PipelineManager;
 class GraphicsPipeline : public PipelineBase
 {
   friend class PipelineManager;
-  GraphicsPipeline(PipelineManager* inOwner, std::size_t inId) : PipelineBase(inOwner, inId) {}
+  GraphicsPipeline(PipelineManager* inOwner, PipelineId inId, ShaderProgramId inShaderProgramId)
+    : PipelineBase(inOwner, inId, inShaderProgramId)
+  {
+  }
 public:
   // Use PipelineManager to create pipelines
   GraphicsPipeline() = default;
@@ -83,6 +86,18 @@ public:
         // Max allowed depth, usually changed for tricky hacks
         .maxDepthBounds = 1.f,
       };
+
+    // For the GPU driver to compile a SPIR-V shader into native GPU bytecode,
+    // on almost all platforms it needs to know at least a little bit of info
+    // about what the shader will be outputting it's result to, i.e. formats
+    // of all attachments. vk::Format::eUndefined here means that the attachment
+    // is not outputted to by this pipeline.
+    struct FragmentShaderOutputDescription
+    {
+      std::vector<vk::Format> colorAttachmentFormats;
+      vk::Format depthAttachmentFormat = vk::Format::eUndefined;
+      vk::Format stencilAttachmentFormat = vk::Format::eUndefined;
+    } fragmentShaderOutput;
   };
 };
 

--- a/etna/include/etna/GraphicsPipeline.hpp
+++ b/etna/include/etna/GraphicsPipeline.hpp
@@ -1,0 +1,102 @@
+#pragma once
+#ifndef ETNA_GRAPHICS_PIPELINE_HPP_INCLUDED
+#define ETNA_GRAPHICS_PIPELINE_HPP_INCLUDED
+
+#include <etna/Vulkan.hpp>
+#include <etna/VertexInput.hpp>
+
+
+namespace etna
+{
+
+class GraphicsPipeline
+{
+public:
+  // The configuration structure is pretty big,
+  // but has sensible defaults for most things,
+  // see below.
+  struct CreateInfo;
+
+  // Don't use directly!
+  GraphicsPipeline(
+    vk::Device device,
+    vk::PipelineLayout layout,
+    std::span<const vk::PipelineShaderStageCreateInfo> stages, 
+    CreateInfo info);
+
+  vk::Pipeline getVkPipeline() const { return pipeline.get(); }
+
+  struct CreateInfo
+  {
+    // Specifies the format in which vertices are fed to this
+    // pipeline's vertex shader
+    VertexShaderInputDescription vertexShaderInput;
+    
+    // Specifies what type of primitives you want to draw:
+    // triangles, lines, etc. Also specifies additional tricky
+    // stuff that is mostly not needed for basic applications.
+    vk::PipelineInputAssemblyStateCreateInfo inputAssemblyConfig =
+      {
+        .topology = vk::PrimitiveTopology::eTriangleList
+      };
+
+    // Configuration for the rasterizer
+    vk::PipelineRasterizationStateCreateInfo rasterizationConfig =
+      {
+        // How polygons should be drawn (filled, outline, only corner points?)
+        .polygonMode = vk::PolygonMode::eFill,
+        // Whether we need to skip drawing back/front faces of polygons
+        .cullMode = vk::CullModeFlagBits::eNone,
+        // Which face we consider to be the front of the polygon
+        .frontFace = vk::FrontFace::eClockwise,
+        // Width of lines when drawing lines/outlines
+        .lineWidth = 1.f,
+      };
+
+    // Configuration for alpha blending.
+    // Disabled and configured to a single color attachment by default.
+    // If you are not trying to do (advanced) transparency techniques,
+    // you do not need this.
+    struct Blending
+    {
+      // Should contain an element for every color attachment that
+      // your pixel shader will output to, i.e. for every output variable.
+      std::vector<vk::PipelineColorBlendAttachmentState> attachments = 
+        {
+          vk::PipelineColorBlendAttachmentState
+          {
+            .blendEnable = false,
+            // Which color channels should we write to?
+            .colorWriteMask = vk::ColorComponentFlagBits::eR
+              | vk::ColorComponentFlagBits::eG
+              | vk::ColorComponentFlagBits::eB
+              | vk::ColorComponentFlagBits::eA
+          }
+        };
+      bool logicOpEnable = false;
+      vk::LogicOp logicOp;
+      std::array<float, 4> blendConstants {0, 0, 0, 0};
+    } blendingConfig;
+
+    vk::PipelineDepthStencilStateCreateInfo depthConfig = 
+      {
+        // Discard fragments that are covered by other fragments?
+        .depthTestEnable = true,
+        // Write fragments' depth into the buffer after they have been drawn?
+        .depthWriteEnable = true,
+        // How should we decide whether one fragment covers another one?
+        .depthCompareOp = vk::CompareOp::eLessOrEqual,
+        // Max allowed depth, usually changed for tricky hacks
+        .maxDepthBounds = 1.f,
+      };
+  };
+
+private:
+  CreateInfo cachedCreateInfo;
+  vk::UniquePipeline pipeline;
+};
+
+}
+
+
+#endif // ETNA_GRAPHICS_PIPELINE_HPP_INCLUDED

--- a/etna/include/etna/GraphicsPipeline.hpp
+++ b/etna/include/etna/GraphicsPipeline.hpp
@@ -4,27 +4,21 @@
 
 #include <etna/Vulkan.hpp>
 #include <etna/VertexInput.hpp>
+#include <etna/PipelineBase.hpp>
 
 
 namespace etna
 {
 
-class GraphicsPipeline
+class PipelineManager;
+
+class GraphicsPipeline : public PipelineBase
 {
+  friend class PipelineManager;
+  GraphicsPipeline(PipelineManager* inOwner, std::size_t inId) : PipelineBase(inOwner, inId) {}
 public:
-  // The configuration structure is pretty big,
-  // but has sensible defaults for most things,
-  // see below.
-  struct CreateInfo;
-
-  // Don't use directly!
-  GraphicsPipeline(
-    vk::Device device,
-    vk::PipelineLayout layout,
-    std::span<const vk::PipelineShaderStageCreateInfo> stages, 
-    CreateInfo info);
-
-  vk::Pipeline getVkPipeline() const { return pipeline.get(); }
+  // Use PipelineManager to create pipelines
+  GraphicsPipeline() = default;
 
   struct CreateInfo
   {
@@ -90,16 +84,6 @@ public:
         .maxDepthBounds = 1.f,
       };
   };
-
-  // Called whenever shaders are reloaded
-  void recreate(
-    vk::Device device,
-    vk::PipelineLayout layout,
-    std::span<const vk::PipelineShaderStageCreateInfo> stages);
-
-private:
-  CreateInfo cachedCreateInfo;
-  vk::UniquePipeline pipeline;
 };
 
 }

--- a/etna/include/etna/GraphicsPipeline.hpp
+++ b/etna/include/etna/GraphicsPipeline.hpp
@@ -91,6 +91,12 @@ public:
       };
   };
 
+  // Called whenever shaders are reloaded
+  void recreate(
+    vk::Device device,
+    vk::PipelineLayout layout,
+    std::span<const vk::PipelineShaderStageCreateInfo> stages);
+
 private:
   CreateInfo cachedCreateInfo;
   vk::UniquePipeline pipeline;

--- a/etna/include/etna/Image.hpp
+++ b/etna/include/etna/Image.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ETNA_IMAGE_HPP_INCLUDED
+#define ETNA_IMAGE_HPP_INCLUDED
 
 #include <etna/Vulkan.hpp>
 #include <vk_mem_alloc.h>
@@ -65,3 +67,5 @@ private:
 };
 
 }
+
+#endif // ETNA_IMAGE_HPP_INCLUDED

--- a/etna/include/etna/PipelineBase.hpp
+++ b/etna/include/etna/PipelineBase.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#ifndef ETNA_PIPELINE_BASE_HPP_INCLUDED
+#define ETNA_PIPELINE_BASE_HPP_INCLUDED
+
+#include <etna/Vulkan.hpp>
+
+
+namespace etna
+{
+
+class PipelineManager;
+
+using PipelineId = std::size_t;
+inline constexpr PipelineId INVALID_PIPELINE_ID = -1;
+
+class PipelineBase
+{
+public:
+  vk::Pipeline getVkPipeline() const;
+
+  PipelineBase(const PipelineBase&) = delete;
+  PipelineBase& operator=(const PipelineBase&) = delete;
+
+  PipelineBase(PipelineBase&&) noexcept;
+  PipelineBase& operator=(PipelineBase&&) noexcept;
+
+protected:
+  PipelineBase(PipelineManager* owner, PipelineId inId);
+  PipelineBase() = default;
+  ~PipelineBase();
+
+private:
+  PipelineManager* owner{nullptr};
+  PipelineId id{INVALID_PIPELINE_ID};
+};
+
+}
+
+#endif // ETNA_PIPELINE_BASE_HPP_INCLUDED

--- a/etna/include/etna/PipelineBase.hpp
+++ b/etna/include/etna/PipelineBase.hpp
@@ -3,19 +3,16 @@
 #define ETNA_PIPELINE_BASE_HPP_INCLUDED
 
 #include <etna/Vulkan.hpp>
+#include <etna/Forward.hpp>
 
 
 namespace etna
 {
 
-class PipelineManager;
-
-using PipelineId = std::size_t;
-inline constexpr PipelineId INVALID_PIPELINE_ID = -1;
-
 class PipelineBase
 {
 public:
+  vk::PipelineLayout getVkPipelineLayout() const;
   vk::Pipeline getVkPipeline() const;
 
   PipelineBase(const PipelineBase&) = delete;
@@ -25,13 +22,14 @@ public:
   PipelineBase& operator=(PipelineBase&&) noexcept;
 
 protected:
-  PipelineBase(PipelineManager* owner, PipelineId inId);
+  PipelineBase(PipelineManager* owner, PipelineId inId, ShaderProgramId inShaderProgramId);
   PipelineBase() = default;
   ~PipelineBase();
 
 private:
   PipelineManager* owner{nullptr};
   PipelineId id{INVALID_PIPELINE_ID};
+  ShaderProgramId shaderProgramId{INVALID_SHADER_PROGRAM_ID};
 };
 
 }

--- a/etna/include/etna/PipelineManager.hpp
+++ b/etna/include/etna/PipelineManager.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#ifndef ETNA_PIPELINE_MANAGER_HPP_INCLUDED
+#define ETNA_PIPELINE_MANAGER_HPP_INCLUDED
+
+#include <unordered_map>
+
+#include <etna/Vulkan.hpp>
+#include <etna/PipelineBase.hpp>
+#include <etna/GraphicsPipeline.hpp>
+
+
+namespace etna
+{
+
+struct ShaderProgramManager;
+
+class PipelineManager
+{
+  friend class PipelineBase;
+public:
+  PipelineManager(vk::Device dev, ShaderProgramManager& shader_manager);
+
+  GraphicsPipeline createGraphicsPipeline(std::string shaderProgramName, GraphicsPipeline::CreateInfo info);
+  // TODO: createComputePipeline, createRaytracePipeline, createMeshletPipeline
+
+  void recreate();
+
+private:
+  void destroyPipeline(PipelineId id);
+  vk::Pipeline getVkPipeline(PipelineId id) const;
+
+private:
+  vk::Device device;
+  ShaderProgramManager& shaderManager;
+
+
+  PipelineId pipelineIdCounter{0};
+  struct PipelineParameters
+  {
+    std::string shaderProgramName;
+    GraphicsPipeline::CreateInfo info;
+  };
+  std::unordered_map<PipelineId, vk::UniquePipeline> pipelines;
+  std::unordered_multimap<PipelineId, PipelineParameters> graphicsPipelineParameters;
+};
+
+}
+
+#endif // ETNA_PIPELINE_MANAGER_HPP_INCLUDED

--- a/etna/include/etna/PipelineManager.hpp
+++ b/etna/include/etna/PipelineManager.hpp
@@ -28,6 +28,7 @@ public:
 private:
   void destroyPipeline(PipelineId id);
   vk::Pipeline getVkPipeline(PipelineId id) const;
+  vk::PipelineLayout getVkPipelineLayout(ShaderProgramId id) const;
 
 private:
   vk::Device device;
@@ -37,7 +38,7 @@ private:
   PipelineId pipelineIdCounter{0};
   struct PipelineParameters
   {
-    std::string shaderProgramName;
+    ShaderProgramId shaderProgram;
     GraphicsPipeline::CreateInfo info;
   };
   std::unordered_map<PipelineId, vk::UniquePipeline> pipelines;

--- a/etna/include/etna/ShaderProgram.hpp
+++ b/etna/include/etna/ShaderProgram.hpp
@@ -3,6 +3,7 @@
 #define ETNA_SHADER_PROGRAM_HPP_INCLUDED
 
 #include <etna/Vulkan.hpp>
+#include <etna/Forward.hpp>
 #include <etna/DescriptorSetLayout.hpp>
 
 #include <array>
@@ -38,9 +39,6 @@ namespace etna
     vk::PushConstantRange pushConst {};
     /*Todo: add vertex input info*/
   };
-
-  struct ShaderProgramManager;
-  using ShaderProgramId = uint32_t;
 
   struct ShaderProgramInfo
   {

--- a/etna/include/etna/ShaderProgram.hpp
+++ b/etna/include/etna/ShaderProgram.hpp
@@ -136,4 +136,4 @@ namespace etna
   };
 }
 
-#endif
+#endif // ETNA_SHADER_PROGRAM_HPP_INCLUDED

--- a/etna/include/etna/VertexInput.hpp
+++ b/etna/include/etna/VertexInput.hpp
@@ -1,0 +1,69 @@
+#pragma once
+#ifndef ETNA_VERTEX_INPUT_HPP_INCLUDED
+#define ETNA_VERTEX_INPUT_HPP_INCLUDED
+
+#include <optional>
+
+#include <etna/Vulkan.hpp>
+
+
+// This structure describes how the vertex shader should interpret
+// a stream of bytes.
+// NOTE: The intention here is for model loading facilities to provide
+// this object to rendering facilities
+struct VertexByteStreamFormatDescription
+{
+  // The size of a single vertex in bytes. You are not required to use
+  // all bytes specified here, i.e. vertices may contain padding.
+  uint32_t stride;
+
+  struct Attribute
+  {
+    // The byte format of this attribute. As an example, R8G8B8A8_UNORM
+    // would mean a 4 component vector which is encoded using 8-bit unsigned
+    // fixed precision numbers (i.e. each byte is interpreted as an unsigned 
+    // integer from 0 to 255, converted to float and divided by 255).
+    // For most purposes you should use R32G32B32A32_SFLOAT -- 32-bit signed
+    // floating point numbers.
+    vk::Format format;
+    // Offset from start of vertex bytes for this attribute
+    uint32_t offset;
+  };
+
+  // Each vertex may contain multiple attributes, e.g. position, normal and UV coords
+  std::vector<Attribute> attributes;
+};
+
+struct VertexShaderInputDescription
+{
+  // Vulkan supports multiple vertex buffer at the same time.
+  // The input variables you define in GLSL shaders have a `binding`
+  // annotation, which is 0 by default, and determines which index buffer
+  // slot will be used for these variables.
+  struct Binding
+  {
+    // Description of the byte stream (i.e. vertex buffer) that will be used
+    // for this binding. It might not make sense that this data must be specified
+    // at pipeline creation time, but most hardware requires this information
+    // to compile SPIR-V code into GPU bytecode, so a pipeline cannot be created
+    // without knowing how bytes will be fed into it.
+    VertexByteStreamFormatDescription byteStreamDescription;
+
+    // How often should variables inside this binding be updated
+    // with a new value? For every "vertex" or every "instance"?
+    vk::VertexInputRate inputRate = vk::VertexInputRate::eInstance;
+
+    // For every input variable inside your GLSL vertex shader with `location = i`,
+    // you should have `attributeMapping[i]` saying which attribute from the
+    // byte stream description should be used for this variable;
+    std::vector<uint32_t> attributeMapping;
+  };
+  
+  // Note that the `binding` annotation value that you specified in GLSL
+  // will be used to index this array. For most use cases, a single element
+  // will be enough.
+  std::vector<std::optional<Binding>> bindings;
+};
+
+
+#endif // ETNA_VERTEX_INPUT_HPP_INCLUDED

--- a/etna/include/etna/VertexInput.hpp
+++ b/etna/include/etna/VertexInput.hpp
@@ -7,6 +7,9 @@
 #include <etna/Vulkan.hpp>
 
 
+namespace etna
+{
+
 // This structure describes how the vertex shader should interpret
 // a stream of bytes.
 // NOTE: The intention here is for model loading facilities to provide
@@ -32,6 +35,14 @@ struct VertexByteStreamFormatDescription
 
   // Each vertex may contain multiple attributes, e.g. position, normal and UV coords
   std::vector<Attribute> attributes;
+
+  std::vector<uint32_t> identityAttributeMapping() const
+  {
+    std::vector<uint32_t> result(attributes.size());
+    for (uint32_t i = 0; i < result.size(); ++i)
+      result[i] = i;
+    return result;
+  }
 };
 
 struct VertexShaderInputDescription
@@ -51,12 +62,13 @@ struct VertexShaderInputDescription
 
     // How often should variables inside this binding be updated
     // with a new value? For every "vertex" or every "instance"?
-    vk::VertexInputRate inputRate = vk::VertexInputRate::eInstance;
+    vk::VertexInputRate inputRate = vk::VertexInputRate::eVertex;
 
     // For every input variable inside your GLSL vertex shader with `location = i`,
     // you should have `attributeMapping[i]` saying which attribute from the
-    // byte stream description should be used for this variable;
-    std::vector<uint32_t> attributeMapping;
+    // byte stream description should be used for this variable.
+    // Default is identity i -> i mapping.
+    std::vector<uint32_t> attributeMapping = byteStreamDescription.identityAttributeMapping();
   };
   
   // Note that the `binding` annotation value that you specified in GLSL
@@ -65,5 +77,6 @@ struct VertexShaderInputDescription
   std::vector<std::optional<Binding>> bindings;
 };
 
+}
 
 #endif // ETNA_VERTEX_INPUT_HPP_INCLUDED

--- a/etna/include/etna/Vulkan.hpp
+++ b/etna/include/etna/Vulkan.hpp
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef ETNA_VULKAN_HPP
+#define ETNA_VULKAN_HPP
+
 // This wrapper has to be used so that our
 // macro customizations work
 #include <etna/Assert.hpp>
@@ -9,3 +13,5 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <vulkan/vulkan.hpp>
+
+#endif // ETNA_VULKAN_HPP

--- a/etna/source/Etna.cpp
+++ b/etna/source/Etna.cpp
@@ -38,6 +38,7 @@ namespace etna
   {
     g_context->getDescriptorSetLayouts().clear(g_context->getDevice());
     g_context->getShaderManager().reloadPrograms();
+    g_context->getPipelineManager().recreate();
     g_context->getDescriptorPool().destroyAllocatedSets();
   }
 

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -214,7 +214,7 @@ namespace etna
     // but it is considered to be abandoned in favour of
     // VK_EXT_debug_utils.
     #ifndef NDEBUG
-      vkInstance->createDebugUtilsMessengerEXTUnique(
+      vkDebugCallback = vkInstance->createDebugUtilsMessengerEXTUnique(
         vk::DebugUtilsMessengerCreateInfoEXT
         {
           .messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eError
@@ -226,7 +226,7 @@ namespace etna
             | vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation,
           .pfnUserCallback = debugCallback,
           .pUserData = this,
-        });
+        }).value;
     #endif
 
     vkPhysDevice = pickPhysicalDevice(vkInstance.get(), params);

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -1,3 +1,4 @@
+#include "etna/ShaderProgram.hpp"
 #include <etna/GlobalContext.hpp>
 #include <etna/Etna.hpp>
 #include <etna/Assert.hpp>
@@ -268,6 +269,8 @@ namespace etna
       
       vmaAllocator = {allocator, &::vmaDestroyAllocator};
     }
+
+    pipelineManager.emplace(vkDevice.get(), shaderPrograms);
     descriptorPool.emplace(vkDevice.get(), params.numFramesInFlight);
   }
   

--- a/etna/source/GraphicsPipeline.cpp
+++ b/etna/source/GraphicsPipeline.cpp
@@ -1,0 +1,89 @@
+#include <etna/GraphicsPipeline.hpp>
+
+namespace etna
+{
+
+GraphicsPipeline::GraphicsPipeline(
+    vk::Device device,
+    vk::PipelineLayout layout,
+    std::span<const vk::PipelineShaderStageCreateInfo> stages, 
+    CreateInfo info)
+{
+  std::vector<vk::VertexInputAttributeDescription> vertexAttribures;
+  std::vector<vk::VertexInputBindingDescription> vertexBindings;
+
+  for (uint32_t i = 0; i < info.vertexShaderInput.bindings.size(); i++)
+  {
+    const auto& bindingDesc = info.vertexShaderInput.bindings[i];
+    if (!bindingDesc.has_value())
+      continue;
+    
+    vertexBindings.emplace_back() =
+      vk::VertexInputBindingDescription
+      {
+        .binding = i,
+        .stride = bindingDesc->byteStreamDescription.stride,
+        .inputRate = bindingDesc->inputRate
+      };
+
+    for (uint32_t j = 0; j < bindingDesc->attributeMapping.size(); ++j)
+    {
+      const auto& attr = bindingDesc->byteStreamDescription
+        .attributes[bindingDesc->attributeMapping[j]];
+      vertexAttribures.emplace_back() =
+        vk::VertexInputAttributeDescription
+        {
+          .location = j,
+          .binding = i,
+          .format = attr.format,
+          .offset = attr.offset
+        };
+    }
+  }
+
+  vk::PipelineVertexInputStateCreateInfo vertexInput {};
+  vertexInput.setVertexAttributeDescriptions(vertexAttribures);
+  vertexInput.setVertexBindingDescriptions(vertexBindings);
+
+
+  vk::PipelineViewportStateCreateInfo viewportState {};
+
+  vk::PipelineMultisampleStateCreateInfo multisampleState
+    {
+      .rasterizationSamples = vk::SampleCountFlagBits::e1,
+      .sampleShadingEnable = false,
+    };
+
+  vk::PipelineColorBlendStateCreateInfo blendState
+    {
+      .logicOpEnable = info.blendingConfig.logicOpEnable,
+      .logicOp = info.blendingConfig.logicOp,
+    };
+  blendState.setAttachments(info.blendingConfig.attachments);
+  blendState.blendConstants = info.blendingConfig.blendConstants;
+
+  std::vector<vk::DynamicState> dynamicStates = {
+    vk::DynamicState::eViewport,
+    vk::DynamicState::eScissor
+  };
+  vk::PipelineDynamicStateCreateInfo dynamicState {};
+  dynamicState.setDynamicStates(dynamicStates);
+  
+  vk::GraphicsPipelineCreateInfo pipelineInfo
+    {
+      .pVertexInputState = &vertexInput,
+      .pInputAssemblyState = &info.inputAssemblyConfig,
+      .pViewportState = &viewportState,
+      .pRasterizationState = &info.rasterizationConfig,
+      .pMultisampleState = &multisampleState,
+      .pDepthStencilState = &info.depthConfig,
+      .pColorBlendState = &blendState,
+      .pDynamicState = &dynamicState,
+      .layout = layout
+    };
+  pipelineInfo.setStages(stages);
+
+  pipeline = device.createGraphicsPipelineUnique(nullptr, pipelineInfo);
+}
+
+}

--- a/etna/source/GraphicsPipeline.cpp
+++ b/etna/source/GraphicsPipeline.cpp
@@ -94,7 +94,7 @@ void GraphicsPipeline::recreate(
     };
   pipelineInfo.setStages(stages);
 
-  pipeline = device.createGraphicsPipelineUnique(nullptr, pipelineInfo);
+  pipeline = device.createGraphicsPipelineUnique(nullptr, pipelineInfo).value;
 }
 
 }

--- a/etna/source/PipelineBase.cpp
+++ b/etna/source/PipelineBase.cpp
@@ -1,5 +1,6 @@
 #include <etna/PipelineBase.hpp>
 #include <etna/PipelineManager.hpp>
+#include <etna/ShaderProgram.hpp>
 
 #include <utility>
 
@@ -7,15 +8,17 @@
 namespace etna
 {
 
-PipelineBase::PipelineBase(PipelineManager* inOwner, std::size_t inId)
+PipelineBase::PipelineBase(PipelineManager* inOwner, PipelineId inId, ShaderProgramId inShaderProgramId)
   : owner{inOwner}
   , id{inId}
+  , shaderProgramId{inShaderProgramId}
 {
 }
 
 PipelineBase::PipelineBase(PipelineBase&& other) noexcept
   : owner{other.owner}
   , id{std::exchange(other.id, INVALID_PIPELINE_ID)}
+  , shaderProgramId{std::exchange(other.shaderProgramId, INVALID_SHADER_PROGRAM_ID)}
 {
 }
 
@@ -28,6 +31,7 @@ PipelineBase& PipelineBase::operator=(PipelineBase&& other) noexcept
     owner->destroyPipeline(id);
   owner = other.owner;
   id = std::exchange(other.id, INVALID_PIPELINE_ID);
+  shaderProgramId = std::exchange(other.shaderProgramId, INVALID_SHADER_PROGRAM_ID);
 
   return *this;
 }
@@ -41,6 +45,11 @@ PipelineBase::~PipelineBase()
 vk::Pipeline PipelineBase::getVkPipeline() const
 {
   return owner->getVkPipeline(id);
+}
+
+vk::PipelineLayout PipelineBase::getVkPipelineLayout() const
+{
+  return owner->getVkPipelineLayout(shaderProgramId);
 }
 
 }

--- a/etna/source/PipelineBase.cpp
+++ b/etna/source/PipelineBase.cpp
@@ -1,0 +1,46 @@
+#include <etna/PipelineBase.hpp>
+#include <etna/PipelineManager.hpp>
+
+#include <utility>
+
+
+namespace etna
+{
+
+PipelineBase::PipelineBase(PipelineManager* inOwner, std::size_t inId)
+  : owner{inOwner}
+  , id{inId}
+{
+}
+
+PipelineBase::PipelineBase(PipelineBase&& other) noexcept
+  : owner{other.owner}
+  , id{std::exchange(other.id, INVALID_PIPELINE_ID)}
+{
+}
+
+PipelineBase& PipelineBase::operator=(PipelineBase&& other) noexcept
+{
+  if (&other == this)
+    return *this;
+
+  if (owner != nullptr)
+    owner->destroyPipeline(id);
+  owner = other.owner;
+  id = std::exchange(other.id, INVALID_PIPELINE_ID);
+
+  return *this;
+}
+
+PipelineBase::~PipelineBase()
+{
+  if (owner != nullptr)
+    owner->destroyPipeline(id);
+}
+
+vk::Pipeline PipelineBase::getVkPipeline() const
+{
+  return owner->getVkPipeline(id);
+}
+
+}


### PR DESCRIPTION
The design is as follows:
We have a pipeline manager that stores creation info for all pipelines ever created, as well as the actual `vk::UniquePipeline`s. Pipeline objects themselves are thin handles that get their data from the manager. This allows the manager to recreate underlying vulkan pipelines when shaders are reloaded, while the user still has an illusion of pipelines being unique objects.

The arguments for creating a graphics pipelines are custom-made structures that allocate arrays on the heap like there's no tomorrow, but allow for pretty initialization code and sensible defaults for most use cases. Only two things need to be always specified: vertex shader input (model format) and fragment shader output (attachment formats). The vertex input parameter is decomposed in a different way to vanilla vulkan, it consists of separate configs for each binding. Inside the binding struct, there are several parts: `VertexByteStreamFormatDescription`, input rate and attribute mapping. The intention here is to decompose the part of this data that describes how a byte stream interpreted as vertices should look and the part that says how it should be fed into the shader. `VertexByteStreamFormatDescription` is the former, `input rate + attribute mapping` is the latter. `vk_graphics_basic` was updated accordingly: the scene manager now only produces a VertexByteStreamFormatDescription structure without deciding which location the input should go into. Why would the scene manager decide that? It's a property of user's shaders, not of the scene!

Also fixed various small issues throughout the framework while I was at it.