### PR TITLE
Fixed small bug with destroying pipelines

### DIFF
--- a/etna/source/PipelineManager.cpp
+++ b/etna/source/PipelineManager.cpp
@@ -133,8 +133,11 @@ void PipelineManager::recreate()
 
 void PipelineManager::destroyPipeline(PipelineId id)
 {
-  if (id != INVALID_PIPELINE_ID)
-    pipelines.erase(id);
+  if (id == INVALID_PIPELINE_ID)
+    return;
+  
+  pipelines.erase(id);
+  graphicsPipelineParameters.erase(id);
 }
 
 vk::Pipeline PipelineManager::getVkPipeline(PipelineId id) const


### PR DESCRIPTION
Destroyed pipelines would get recreated when shaders are reloaded, oops