### PR TITLE
Etna wrappers cleanup

### DIFF
--- a/etna/include/etna/Buffer.hpp
+++ b/etna/include/etna/Buffer.hpp
@@ -37,6 +37,7 @@ public:
   void unmap();
 
   ~Buffer();
+  void reset();
 
 private:
   VmaAllocator allocator{};

--- a/etna/include/etna/Image.hpp
+++ b/etna/include/etna/Image.hpp
@@ -56,7 +56,7 @@ private:
       return hasher(params.baseMip);
     }
   };
-  mutable std::unordered_map<ViewParams, vk::ImageView, ViewParamsHasher> views;
+  mutable std::unordered_map<ViewParams, vk::UniqueImageView, ViewParamsHasher> views;
   VmaAllocator allocator{};
 
   VmaAllocation allocation{};

--- a/etna/include/etna/Sampler.hpp
+++ b/etna/include/etna/Sampler.hpp
@@ -22,8 +22,6 @@ public:
 
   [[nodiscard]] vk::Sampler get() const { return sampler.get(); }
 
-  void reset();
-
 private:
   vk::UniqueSampler sampler{};
 };

--- a/etna/include/etna/Sampler.hpp
+++ b/etna/include/etna/Sampler.hpp
@@ -20,20 +20,12 @@ public:
 
   Sampler(CreateInfo info);
 
-  Sampler(const Sampler&) = delete;
-  Sampler& operator=(const Sampler&) = delete;
+  [[nodiscard]] vk::Sampler get() const { return sampler.get(); }
 
-  void swap(Sampler& other);
-  Sampler(Sampler&&) noexcept;
-  Sampler& operator=(Sampler&&) noexcept;
-
-  [[nodiscard]] vk::Sampler get() const { return sampler; }
-
-  ~Sampler();
   void reset();
 
 private:
-  vk::Sampler sampler{};
+  vk::UniqueSampler sampler{};
 };
 
 }

--- a/etna/source/Sampler.cpp
+++ b/etna/source/Sampler.cpp
@@ -19,12 +19,7 @@ Sampler::Sampler(CreateInfo info)
     .maxLod = 1.0f,
     .borderColor = vk::BorderColor::eFloatOpaqueWhite
   };
-  sampler = etna::get_context().getDevice().createSampler(createInfo).value;
-}
-
-void Sampler::reset()
-{
-  sampler.reset();
+  sampler = etna::get_context().getDevice().createSamplerUnique(createInfo).value;
 }
 
 }

--- a/etna/source/Sampler.cpp
+++ b/etna/source/Sampler.cpp
@@ -24,32 +24,7 @@ Sampler::Sampler(CreateInfo info)
 
 void Sampler::reset()
 {
-  etna::get_context().getDevice().destroySampler(sampler);
-}
-
-Sampler::~Sampler()
-{
-  reset();
-}
-
-void Sampler::swap(Sampler& other)
-{
-  vk::Sampler tmp = other.sampler;
-  other.sampler = sampler;
-  sampler = tmp;
-}
-
-Sampler::Sampler(Sampler&& other)  noexcept
-{
-  swap(other);
-  other.reset();
-}
-
-Sampler& Sampler::operator=(Sampler&& other)  noexcept
-{
-  swap(other);
-  other.reset();
-  return *this;
+  sampler.reset();
 }
 
 }


### PR DESCRIPTION
* Use `vk::UniqueXxx` instead of `vk::Xxx` to simplify code
* Assert with informative messages instead of throwing exceptions that will never be caught anywhere anyway
* Fixed a crash when assigning to a mapped buffer
* Unify Image and Buffer: both implement rule of 3 using `swap` and `reset` to avoid copypasta