### PR TITLE
Add ComputePipeline

### DIFF
--- a/etna/include/etna/ComputePipeline.hpp
+++ b/etna/include/etna/ComputePipeline.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#ifndef ETNA_COMPUTE_PIPELINE_HPP_INCLUDED
+#define ETNA_COMPUTE_PIPELINE_HPP_INCLUDED
+
+#include <etna/Vulkan.hpp>
+#include <etna/VertexInput.hpp>
+#include <etna/PipelineBase.hpp>
+#include <variant>
+
+namespace etna
+{
+
+class PipelineManager;
+
+class ComputePipeline: public PipelineBase
+{
+  friend class PipelineManager;
+  ComputePipeline(PipelineManager *inOwner, PipelineId inId, ShaderProgramId inShaderProgramId)
+    : PipelineBase(inOwner, inId, inShaderProgramId)
+  {
+  }
+public:
+  // Use PipelineManager to create pipelines
+  ComputePipeline() = default;
+  struct CreateInfo
+  {
+    // The only info we need is VkPipelineShaderStageCreateInfo
+    vk::PipelineShaderStageCreateInfo stage = {};
+  };
+
+};
+}
+
+#endif // ETNA_COMPUTE_PIPELINE_HPP_INCLUDED

--- a/etna/include/etna/ComputePipeline.hpp
+++ b/etna/include/etna/ComputePipeline.hpp
@@ -22,11 +22,7 @@ class ComputePipeline: public PipelineBase
 public:
   // Use PipelineManager to create pipelines
   ComputePipeline() = default;
-  struct CreateInfo
-  {
-    // The only info we need is VkPipelineShaderStageCreateInfo
-    vk::PipelineShaderStageCreateInfo stage = {};
-  };
+  struct CreateInfo{};
 
 };
 }

--- a/etna/include/etna/PipelineManager.hpp
+++ b/etna/include/etna/PipelineManager.hpp
@@ -7,7 +7,7 @@
 #include <etna/Vulkan.hpp>
 #include <etna/PipelineBase.hpp>
 #include <etna/GraphicsPipeline.hpp>
-
+#include <etna/ComputePipeline.hpp>
 
 namespace etna
 {
@@ -21,7 +21,9 @@ public:
   PipelineManager(vk::Device dev, ShaderProgramManager& shader_manager);
 
   GraphicsPipeline createGraphicsPipeline(std::string shaderProgramName, GraphicsPipeline::CreateInfo info);
-  // TODO: createComputePipeline, createRaytracePipeline, createMeshletPipeline
+
+  ComputePipeline createComputePipeline(std::string shaderProgramName, ComputePipeline::CreateInfo info);
+  // TODO: createRaytracePipeline, createMeshletPipeline
 
   void recreate();
 
@@ -41,7 +43,14 @@ private:
     ShaderProgramId shaderProgram;
     GraphicsPipeline::CreateInfo info;
   };
+
+  struct ComputeParameters
+  {
+    ShaderProgramId shaderProgram;
+    ComputePipeline::CreateInfo info;
+  };
   std::unordered_map<PipelineId, vk::UniquePipeline> pipelines;
+  std::unordered_multimap<PipelineId, ComputeParameters> computePipelineParameters;
   std::unordered_multimap<PipelineId, PipelineParameters> graphicsPipelineParameters;
 };
 

--- a/etna/source/PipelineManager.cpp
+++ b/etna/source/PipelineManager.cpp
@@ -128,15 +128,16 @@ ComputePipeline PipelineManager::createComputePipeline(std::string shader_progra
 {
   const PipelineId pipelineId = pipelineIdCounter++;  
   const ShaderProgramId progId = shaderManager.getProgram(shader_program_name);
+  const std::vector<vk::PipelineShaderStageCreateInfo> shaderStages = shaderManager.getShaderStages(progId);
 
-  ETNA_ASSERT(shaderManager.getShaderStages(progId).size() == 1,
+  ETNA_ASSERT(shaderStages.size() == 1,
     "Incorrect shader program, expected 1 stage for ComputePipeline, but got %d!",
-    shaderManager.getShaderStages(progId).size());
+    shaderStages.size());
 
   pipelines.emplace(pipelineId,
     createComputePipelineInternal(device,
       shaderManager.getProgramLayout(progId),
-      shaderManager.getShaderStages(progId)[0], info));
+      shaderStages[0], info));
   computePipelineParameters.emplace(pipelineId, ComputeParameters{progId, std::move(info)});
   
   return ComputePipeline(this, pipelineId, progId);

--- a/etna/source/PipelineManager.cpp
+++ b/etna/source/PipelineManager.cpp
@@ -12,7 +12,7 @@ namespace etna
 vk::UniquePipeline createComputePipelineInternal(
   vk::Device device,
   vk::PipelineLayout layout,
-  std::span<const vk::PipelineShaderStageCreateInfo> stages,
+  const vk::PipelineShaderStageCreateInfo stage,
   const ComputePipeline::CreateInfo& info)
 {
   
@@ -20,7 +20,7 @@ vk::UniquePipeline createComputePipelineInternal(
     {
       .layout = layout
     };
-  pipelineInfo.setStage(stages[0]);
+  pipelineInfo.setStage(stage);
 
   return device.createComputePipelineUnique(nullptr, pipelineInfo).value;
 }
@@ -132,7 +132,7 @@ ComputePipeline PipelineManager::createComputePipeline(std::string shader_progra
   pipelines.emplace(pipelineId,
     createComputePipelineInternal(device,
       shaderManager.getProgramLayout(progId),
-      shaderManager.getShaderStages(progId), info));
+      shaderManager.getShaderStages(progId)[0], info));
   computePipelineParameters.emplace(pipelineId, ComputeParameters{progId, std::move(info)});
   
   return ComputePipeline(this, pipelineId, progId);

--- a/etna/source/PipelineManager.cpp
+++ b/etna/source/PipelineManager.cpp
@@ -129,6 +129,10 @@ ComputePipeline PipelineManager::createComputePipeline(std::string shader_progra
   const PipelineId pipelineId = pipelineIdCounter++;  
   const ShaderProgramId progId = shaderManager.getProgram(shader_program_name);
 
+  ETNA_ASSERT(shaderManager.getShaderStages(progId).size() == 1,
+    "Incorrect shader program, expected 1 stage for ComputePipeline, but got %d!",
+    shaderManager.getShaderStages(progId).size());
+
   pipelines.emplace(pipelineId,
     createComputePipelineInternal(device,
       shaderManager.getProgramLayout(progId),


### PR DESCRIPTION
Currently supported addition for computePipeline like this:
`m_cullingPipeline      = pipelineManager.createComputePipeline("culling", {});`
I'm not sure if it works correctly, but for current state I have no validation errors on the stage of creation computePipeline.