### PR TITLE
Refactor of shader program related stuff

### DIFF
--- a/etna/include/etna/DescriptorSet.hpp
+++ b/etna/include/etna/DescriptorSet.hpp
@@ -16,7 +16,7 @@ namespace etna
       : generation {gen}, layoutId {id}, set {vk_set} {}
 
     bool isValid() const;
-    
+
     vk::DescriptorSet getVkSet() const
     {
       return set;
@@ -39,13 +39,13 @@ namespace etna
   };
 
   /*Base version. Allocate and use descriptor sets while writing command buffer, they will be destroyed
-  automaticaly. Resource allocation tracking shoud be added. 
+  automaticaly. Resource allocation tracking shoud be added.
   For long-living descriptor sets (e.g bindless resource sets) separate allocator shoud be added, with ManagedDescriptorSet with destructor*/
   struct DynamicDescriptorPool
   {
     DynamicDescriptorPool(vk::Device dev, uint32_t framesInFlight);
     ~DynamicDescriptorPool();
-    
+
     void flip();
     void destroyAllocatedSets();
     void reset(uint32_t frames_in_flight);
@@ -56,7 +56,7 @@ namespace etna
     {
       return pools[frameIndex];
     }
-    
+
     uint64_t getNumFlips() const
     {
       return flipsCount;
@@ -83,7 +83,7 @@ namespace etna
       : binding {rbinding}, arrayElem {array_index}, resources {image_info} {}
     Binding(uint32_t rbinding, const vk::DescriptorBufferInfo &buffer_info, uint32_t array_index = 0)
       : binding {rbinding}, arrayElem {array_index}, resources {buffer_info} {}
-  
+
     uint32_t binding;
     uint32_t arrayElem;
     std::variant<vk::DescriptorImageInfo, vk::DescriptorBufferInfo> resources;

--- a/etna/include/etna/DescriptorSetLayout.hpp
+++ b/etna/include/etna/DescriptorSetLayout.hpp
@@ -16,7 +16,7 @@ namespace etna
 {
   constexpr uint32_t MAX_PROGRAM_DESCRIPTORS = 4u;
   constexpr uint32_t MAX_DESCRIPTOR_BINDINGS = 32u; /*If you are out of bindings, try using arrays of images/samplers*/
-  
+
   struct DescriptorSetLayoutHash;
 
   struct DescriptorSetInfo
@@ -33,7 +33,7 @@ namespace etna
 
     bool isBindingUsed(uint32_t binding) const
     {
-      return binding < maxUsedBinding && usedBindings.test(binding);  
+      return binding < maxUsedBinding && usedBindings.test(binding);
     }
 
     const vk::DescriptorSetLayoutBinding &getBinding(uint32_t binding) const
@@ -63,7 +63,7 @@ namespace etna
   {
     DescriptorSetLayoutCache() {}
     ~DescriptorSetLayoutCache() { /*make device global and call clear hear*/}
-    
+
     DescriptorLayoutId registerLayout(vk::Device device, const DescriptorSetInfo &info);
     void clear(vk::Device device);
 
@@ -80,7 +80,7 @@ namespace etna
     std::pair<DescriptorLayoutId, vk::DescriptorSetLayout> get(vk::Device device, const DescriptorSetInfo &info);
 
     DescriptorSetLayoutCache(const DescriptorSetLayoutCache&) = delete;
-    DescriptorSetLayoutCache &operator=(const DescriptorSetLayoutCache&) = delete; 
+    DescriptorSetLayoutCache &operator=(const DescriptorSetLayoutCache&) = delete;
 
   private:
     std::unordered_map<DescriptorSetInfo, DescriptorLayoutId, DescriptorSetLayoutHash> map;

--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -41,8 +41,8 @@ namespace etna
 
   void submit();
 
-  ShaderProgramId create_program(const std::string &name, const std::vector<std::string> &shaders_path);
-  
+  ShaderProgramId create_program(const std::string &name, const std::vector<std::filesystem::path> &shaders_path);
+
   /*
     Reload shader files. Warning:
     1) This function must be called from gpu idle state

--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -38,7 +38,7 @@ namespace etna
   bool is_initilized();
   void initialize(const InitParams &params);
   void shutdown();
-  
+
   void submit();
 
   ShaderProgramId create_program(const std::string &name, const std::vector<std::string> &shaders_path);
@@ -53,7 +53,7 @@ namespace etna
   ShaderProgramInfo get_shader_program(ShaderProgramId id);
   ShaderProgramInfo get_shader_program(const std::string &name);
 
-  
+
   DescriptorSet create_descriptor_set(DescriptorLayoutId layout, const vk::ArrayProxy<const Binding> &bindings);
 
   void set_state(vk::CommandBuffer com_buffer, vk::Image image,

--- a/etna/include/etna/GlobalContext.hpp
+++ b/etna/include/etna/GlobalContext.hpp
@@ -34,7 +34,7 @@ namespace etna
     vk::Queue getQueue() const { return universalQueue; }
     uint32_t getQueueFamilyIdx() const { return universalQueueFamilyIdx; }
 
-    ShaderProgramManager &getShaderManager() { return shaderPrograms; }
+    ShaderProgramManager &getShaderManager() { return *shaderPrograms; }
     PipelineManager &getPipelineManager() { return pipelineManager.value(); }
     DescriptorSetLayoutCache &getDescriptorSetLayouts() { return descriptorSetLayouts; }
     DynamicDescriptorPool &getDescriptorPool() { return *descriptorPool; }
@@ -58,8 +58,8 @@ namespace etna
 
     std::unique_ptr<VmaAllocator_T, void(*)(VmaAllocator)> vmaAllocator{nullptr, nullptr};
 
-    DescriptorSetLayoutCache descriptorSetLayouts {}; 
-    ShaderProgramManager shaderPrograms {};
+    DescriptorSetLayoutCache descriptorSetLayouts {};
+    std::optional<ShaderProgramManager> shaderPrograms;
 
     // Optionals for late init
     std::optional<PipelineManager> pipelineManager;

--- a/etna/include/etna/GraphicsPipeline.hpp
+++ b/etna/include/etna/GraphicsPipeline.hpp
@@ -28,7 +28,7 @@ public:
     // Specifies the format in which vertices are fed to this
     // pipeline's vertex shader
     VertexShaderInputDescription vertexShaderInput;
-    
+
     // Specifies what type of primitives you want to draw:
     // triangles, lines, etc. Also specifies additional tricky
     // stuff that is mostly not needed for basic applications.
@@ -58,7 +58,7 @@ public:
     {
       // Should contain an element for every color attachment that
       // your pixel shader will output to, i.e. for every output variable.
-      std::vector<vk::PipelineColorBlendAttachmentState> attachments = 
+      std::vector<vk::PipelineColorBlendAttachmentState> attachments =
         {
           vk::PipelineColorBlendAttachmentState
           {
@@ -75,7 +75,7 @@ public:
       std::array<float, 4> blendConstants {0, 0, 0, 0};
     } blendingConfig = {};
 
-    vk::PipelineDepthStencilStateCreateInfo depthConfig = 
+    vk::PipelineDepthStencilStateCreateInfo depthConfig =
       {
         // Discard fragments that are covered by other fragments?
         .depthTestEnable = true,

--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -13,22 +13,22 @@ namespace etna
 
 class RenderTargetState
 {
-    VkCommandBuffer commandBuffer;
-    static bool inScope;
+  VkCommandBuffer commandBuffer;
+  static bool inScope;
 public:
-    struct AttachmentParams
-    {
-        // TODO: Add new fields for clearing etc.
-        vk::Image image = VK_NULL_HANDLE;
-        vk::ImageView view = VK_NULL_HANDLE;
-        AttachmentParams() = default;
-        AttachmentParams(vk::Image i, vk::ImageView v) : image(i), view(v) {}
-        AttachmentParams(const Image &img) : image(img.get()), view(img.getView({})) {}
-    };
+  struct AttachmentParams
+  {
+    // TODO: Add new fields for clearing etc.
+    vk::Image image = VK_NULL_HANDLE;
+    vk::ImageView view = VK_NULL_HANDLE;
+    AttachmentParams() = default;
+    AttachmentParams(vk::Image i, vk::ImageView v) : image(i), view(v) {}
+    AttachmentParams(const Image &img) : image(img.get()), view(img.getView({})) {}
+  };
 
-    RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend,
-    const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment);
-    ~RenderTargetState();
+  RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend,
+  const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment);
+  ~RenderTargetState();
 };
 
 }

--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -25,7 +25,7 @@ public:
         AttachmentParams(vk::Image i, vk::ImageView v) : image(i), view(v) {}
         AttachmentParams(const Image &img) : image(img.get()), view(img.getView({})) {}
     };
-    
+
     RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend,
     const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment);
     ~RenderTargetState();

--- a/etna/include/etna/ShaderProgram.hpp
+++ b/etna/include/etna/ShaderProgram.hpp
@@ -62,9 +62,15 @@ namespace etna
     friend ShaderProgramManager;
   };
 
+  struct DescriptorSetLayoutCache;
+
   struct ShaderProgramManager
   {
-    ShaderProgramManager() {}
+    ShaderProgramManager(vk::Device dev, DescriptorSetLayoutCache& descSetLayoutCache)
+      : vkDevice{dev}, descriptorSetLayoutCache{descSetLayoutCache}
+    {
+    }
+
     ~ShaderProgramManager() { clear(); }
 
     ShaderProgramId loadProgram(std::string_view name, std::span<const std::filesystem::path> shaders_path);
@@ -102,6 +108,9 @@ namespace etna
     ShaderProgramManager &operator=(const ShaderProgramManager &) = delete;
 
   private:
+    vk::Device vkDevice;
+    DescriptorSetLayoutCache& descriptorSetLayoutCache;
+
     std::unordered_map<std::filesystem::path, uint32_t> shaderModuleNames;
     std::vector<std::unique_ptr<ShaderModule>> shaderModules;
 

--- a/etna/include/etna/ShaderProgram.hpp
+++ b/etna/include/etna/ShaderProgram.hpp
@@ -111,7 +111,7 @@ namespace etna
     vk::Device vkDevice;
     DescriptorSetLayoutCache& descriptorSetLayoutCache;
 
-    std::unordered_map<std::filesystem::path, uint32_t> shaderModuleNames;
+    std::unordered_map<std::filesystem::path, uint32_t> shaderModulePathToId;
     std::vector<std::unique_ptr<ShaderModule>> shaderModules;
 
     uint32_t registerModule(const std::filesystem::path& path);

--- a/etna/include/etna/ShaderProgram.hpp
+++ b/etna/include/etna/ShaderProgram.hpp
@@ -10,15 +10,15 @@
 #include <array>
 #include <bitset>
 #include <vector>
-#include <unordered_map>
 #include <memory>
+#include <filesystem>
 
 
 namespace etna
 {
   struct ShaderModule
   {
-    ShaderModule(vk::Device device, const std::string &shader_path);
+    ShaderModule(vk::Device device, std::filesystem::path shader_path);
 
     void reload(vk::Device device);
 
@@ -30,7 +30,7 @@ namespace etna
     vk::PushConstantRange getPushConst() const { return pushConst; }
 
   private:
-    std::string path {};
+    std::filesystem::path path;
     std::string entryPoint;
     vk::ShaderStageFlagBits stage;
 
@@ -67,7 +67,7 @@ namespace etna
     ShaderProgramManager() {}
     ~ShaderProgramManager() { clear(); }
 
-    ShaderProgramId loadProgram(std::string_view name, const std::vector<std::string> &shaders_path);
+    ShaderProgramId loadProgram(std::string_view name, std::span<const std::filesystem::path> shaders_path);
     ShaderProgramId getProgram(std::string_view name) const;
 
     ShaderProgramInfo getProgramInfo(ShaderProgramId id) const
@@ -102,10 +102,10 @@ namespace etna
     ShaderProgramManager &operator=(const ShaderProgramManager &) = delete;
 
   private:
-    std::unordered_map<std::string, uint32_t> shaderModuleNames;
+    std::unordered_map<std::filesystem::path, uint32_t> shaderModuleNames;
     std::vector<std::unique_ptr<ShaderModule>> shaderModules;
 
-    uint32_t registerModule(const std::string &path);
+    uint32_t registerModule(const std::filesystem::path& path);
     const ShaderModule &getModule(uint32_t id) const { return *shaderModules.at(id); }
 
     struct ShaderProgramInternal

--- a/etna/include/etna/ShaderProgram.hpp
+++ b/etna/include/etna/ShaderProgram.hpp
@@ -80,7 +80,9 @@ namespace etna
       return getProgramInfo(getProgram(name));
     }
 
-    void reloadPrograms(); 
+    void logProgramInfo(const std::string& name) const;
+
+    void reloadPrograms();
     void clear();
 
     vk::PipelineLayout getProgramLayout(ShaderProgramId id) const { return programs.at(id)->progLayout.get(); } 

--- a/etna/include/etna/VertexInput.hpp
+++ b/etna/include/etna/VertexInput.hpp
@@ -70,7 +70,7 @@ struct VertexShaderInputDescription
     // Default is identity i -> i mapping.
     std::vector<uint32_t> attributeMapping = byteStreamDescription.identityAttributeMapping();
   };
-  
+
   // Note that the `binding` annotation value that you specified in GLSL
   // will be used to index this array. For most use cases, a single element
   // will be enough.

--- a/etna/include/etna/detail/StringMap.hpp
+++ b/etna/include/etna/detail/StringMap.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#ifndef ETNA_STRING_MAP_HPP_INCLUDED
+#define ETNA_STRING_MAP_HPP_INCLUDED
+
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+
+namespace etna
+{
+
+namespace detail
+{
+
+// Transparent policies so that everything works with string_views
+// Copied from a MSVC STL github issue
+
+struct string_compare
+{
+  using is_transparent = void;
+
+  bool operator()(std::string_view key, std::string_view txt) const { return key == txt; }
+  bool operator()(std::string key, std::string_view txt) const { return key == txt; }
+};
+
+struct string_hash
+{
+  using is_transparent = void;
+  using transparent_key_equal = string_compare;
+
+  size_t operator()(std::string_view txt) const { return std::hash<std::string_view>{}(txt); }
+  size_t operator()(const std::string& txt) const { return std::hash<std::string>{}(txt); }
+};
+
+}
+
+template<class Value, class Allocator = std::allocator<std::pair<const std::string, Value>>>
+using StringMap = std::unordered_map<std::string, Value, detail::string_hash, detail::string_compare, Allocator>;
+
+}
+
+#endif // ETNA_STRING_MAP_HPP_INCLUDED

--- a/etna/source/DescriptorSet.cpp
+++ b/etna/source/DescriptorSet.cpp
@@ -15,9 +15,9 @@ namespace etna
   /*Todo: Add struct with parameters*/
   static constexpr uint32_t NUM_DESCRIPORS = 2048;
 
-  static constexpr uint32_t NUM_TEXTURES = 2048; 
+  static constexpr uint32_t NUM_TEXTURES = 2048;
   static constexpr uint32_t NUM_RW_TEXTURES = 512;
-  static constexpr uint32_t NUM_BUFFERS = 2048; 
+  static constexpr uint32_t NUM_BUFFERS = 2048;
   static constexpr uint32_t NUM_RW_BUFFERS = 512;
   static constexpr uint32_t NUM_SAMPLERS = 128;
 
@@ -65,7 +65,7 @@ namespace etna
     for (uint32_t i = 0; i < numFrames; i++)
       flip();
   }
-    
+
   DescriptorSet DynamicDescriptorPool::allocateSet(DescriptorLayoutId layoutId)
   {
     auto &dslCache = get_context().getDescriptorSetLayouts();
@@ -110,7 +110,7 @@ namespace etna
 
     for (uint32_t binding = 0; binding < MAX_DESCRIPTOR_BINDINGS; binding++)
     {
-      unboundResources[binding] = 
+      unboundResources[binding] =
         layoutInfo.isBindingUsed(binding)? layoutInfo.getBinding(binding).descriptorCount : 0u;
     }
 
@@ -120,7 +120,7 @@ namespace etna
         ETNA_PANIC("Descriptor write error: descriptor set doesn't have ", binding.binding, " slot");
 
       auto &bindingInfo = layoutInfo.getBinding(binding.binding);
-      bool isImageRequied = is_image_resource(bindingInfo.descriptorType); 
+      bool isImageRequied = is_image_resource(bindingInfo.descriptorType);
       bool isImageBinding = std::get_if<vk::DescriptorImageInfo>(&binding.resources) != nullptr;
       if (isImageRequied != isImageBinding)
       {

--- a/etna/source/DescriptorSetLayout.cpp
+++ b/etna/source/DescriptorSetLayout.cpp
@@ -139,14 +139,14 @@ namespace etna
     auto it = map.find(info);
     if (it != map.end())
       return {it->second, vkLayouts[it->second]};
-    
+
     DescriptorLayoutId id = static_cast<DescriptorLayoutId>(descriptors.size());
     map.insert({info, id});
     descriptors.push_back(info);
     vkLayouts.push_back(info.createVkLayout(device));
     return {id, vkLayouts[id]};
   }
-  
+
   void DescriptorSetLayoutCache::clear(vk::Device device)
   {
     for (auto layout : vkLayouts) {

--- a/etna/source/Etna.cpp
+++ b/etna/source/Etna.cpp
@@ -14,24 +14,24 @@ namespace etna
   {
     return *g_context;
   }
-  
+
   bool is_initilized()
   {
     return static_cast<bool>(g_context);
   }
-  
+
   void initialize(const InitParams &params)
   {
     g_context.reset(new GlobalContext(params));
   }
-  
+
   void shutdown()
   {
     g_context->getDescriptorSetLayouts().clear(g_context->getDevice());
     g_context.reset(nullptr);
   }
 
-  ShaderProgramId create_program(const std::string &name, const std::vector<std::string> &shaders_path)
+  ShaderProgramId create_program(const std::string &name, const std::vector<std::filesystem::path> &shaders_path)
   {
     return g_context->getShaderManager().loadProgram(name, shaders_path);
   }
@@ -48,7 +48,7 @@ namespace etna
   {
     return g_context->getShaderManager().getProgramInfo(id);
   }
-  
+
   ShaderProgramInfo get_shader_program(const std::string &name)
   {
     return g_context->getShaderManager().getProgramInfo(name);

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -38,7 +38,7 @@ namespace etna
       {
         .pApplicationInfo = &appInfo,
       };
-    
+
     createInfo.setPEnabledLayerNames(layers);
     createInfo.setPEnabledExtensionNames(extensions);
 
@@ -48,11 +48,11 @@ namespace etna
   static bool checkPhysicalDeviceSupportsExtensions(vk::PhysicalDevice pdevice, std::span<char const * const> extensions)
   {
     std::vector availableExtensions = pdevice.enumerateDeviceExtensionProperties().value;
-    
+
     std::unordered_set requestedExtensions(extensions.begin(), extensions.end());
     for (const auto &ext : availableExtensions)
       requestedExtensions.erase(ext.extensionName);
-    
+
     return requestedExtensions.empty();
   }
 
@@ -111,7 +111,7 @@ namespace etna
 
       if (!checkPhysicalDeviceSupportsExtensions(pdevice, params.deviceExtensions))
         continue;
-        
+
       if (deviceTypeIsBetter(props.deviceType, bestDeviceProps.deviceType))
       {
         bestDevice = pdevice;
@@ -121,7 +121,7 @@ namespace etna
 
     return bestDevice;
   }
-  
+
   uint32_t getQueueFamilyIndex(vk::PhysicalDevice pdevice, vk::QueueFlags flags)
   {
     std::vector queueFamilies = pdevice.getQueueFamilyProperties();
@@ -136,7 +136,7 @@ namespace etna
 
     ETNA_PANIC("Could not find a queue family that supports all requested flags!");
   }
-  
+
   static vk::UniqueDevice createDevice(vk::PhysicalDevice pdevice,
     uint32_t universalQueueFamily, const InitParams &params)
   {
@@ -186,7 +186,7 @@ namespace etna
         .ppEnabledExtensionNames = deviceExtensions.data(),
       }).value;
   }
-  
+
 #ifndef NDEBUG
   static VkBool32 debugCallback(
     VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
@@ -228,10 +228,10 @@ namespace etna
     vk::DynamicLoader dl;
     VULKAN_HPP_DEFAULT_DISPATCHER.init(
       dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr"));
-    
+
     vkInstance = createInstance(params);
     VULKAN_HPP_DEFAULT_DISPATCHER.init(vkInstance.get());
-    
+
     // NOTE: Previously we used VK_EXT_debug_report extension,
     // but it is considered to be abandoned in favour of
     // VK_EXT_debug_utils.
@@ -272,30 +272,31 @@ namespace etna
           .flags = {},
           .physicalDevice = vkPhysDevice,
           .device = vkDevice.get(),
-          
+
           .preferredLargeHeapBlockSize = {},
           .pAllocationCallbacks = {},
           .pDeviceMemoryCallbacks = {},
           .pHeapSizeLimit = {},
           .pVulkanFunctions = {},
-          
+
           .instance = vkInstance.get(),
           .vulkanApiVersion = VULKAN_API_VERSION,
           .pTypeExternalMemoryHandleTypes = nullptr
         };
-      
+
       VmaAllocator allocator;
       ::vmaCreateAllocator(&alloc_info, &allocator);
-      
+
       vmaAllocator = {allocator, &::vmaDestroyAllocator};
     }
 
-    pipelineManager.emplace(vkDevice.get(), shaderPrograms);
+    shaderPrograms.emplace(vkDevice.get(), descriptorSetLayouts);
+    pipelineManager.emplace(vkDevice.get(), *shaderPrograms);
     descriptorPool.emplace(vkDevice.get(), params.numFramesInFlight);
 
     resourceTracking = std::make_unique<ResourceStates>();
   }
-  
+
   Image GlobalContext::createImage(Image::CreateInfo info)
   {
     return Image(vmaAllocator.get(), info);

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -252,7 +252,7 @@ namespace etna
     #endif
 
     vkPhysDevice = pickPhysicalDevice(vkInstance.get(), params);
-    
+
 
     constexpr auto UNIVERSAL_QUEUE_FLAGS =
       vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute | vk::QueueFlagBits::eTransfer;

--- a/etna/source/Image.cpp
+++ b/etna/source/Image.cpp
@@ -72,7 +72,7 @@ void Image::reset()
 {
   if (!image)
     return;
-  
+
   views.clear();
   vmaDestroyImage(allocator, VkImage(image), allocation);
   allocator = {};
@@ -104,7 +104,7 @@ static vk::ImageAspectFlags get_aspeck_mask(vk::Format format)
 vk::ImageView Image::getView(Image::ViewParams params) const
 {
   auto it = views.find(params);
-  
+
   if (it == views.end())
   {
     vk::ImageViewCreateInfo viewInfo

--- a/etna/source/PipelineManager.cpp
+++ b/etna/source/PipelineManager.cpp
@@ -1,7 +1,6 @@
 #include "etna/Assert.hpp"
 #include <etna/PipelineManager.hpp>
 
-#include <iostream>
 #include <span>
 #include <vector>
 #include <etna/ShaderProgram.hpp>
@@ -15,7 +14,6 @@ static vk::UniquePipeline createComputePipelineInternal(
   vk::PipelineLayout layout,
   const vk::PipelineShaderStageCreateInfo stage)
 {
-  
   vk::ComputePipelineCreateInfo pipelineInfo
     {
       .layout = layout
@@ -40,7 +38,7 @@ vk::UniquePipeline createGraphicsPipelineInternal(
     const auto& bindingDesc = info.vertexShaderInput.bindings[i];
     if (!bindingDesc.has_value())
       continue;
-    
+
     vertexBindings.emplace_back() =
       vk::VertexInputBindingDescription
       {
@@ -96,13 +94,13 @@ vk::UniquePipeline createGraphicsPipelineInternal(
   vk::PipelineDynamicStateCreateInfo dynamicState {};
   dynamicState.setDynamicStates(dynamicStates);
 
-  vk::PipelineRenderingCreateInfo rendering 
+  vk::PipelineRenderingCreateInfo rendering
     {
       .depthAttachmentFormat = info.fragmentShaderOutput.depthAttachmentFormat,
       .stencilAttachmentFormat = info.fragmentShaderOutput.stencilAttachmentFormat
     };
   rendering.setColorAttachmentFormats(info.fragmentShaderOutput.colorAttachmentFormats);
-  
+
   vk::GraphicsPipelineCreateInfo pipelineInfo
     {
       .pNext = &rendering,
@@ -130,7 +128,7 @@ PipelineManager::PipelineManager(vk::Device dev, ShaderProgramManager& shader_ma
 
 ComputePipeline PipelineManager::createComputePipeline(std::string shader_program_name, ComputePipeline::CreateInfo info)
 {
-  const PipelineId pipelineId = pipelineIdCounter++;  
+  const PipelineId pipelineId = pipelineIdCounter++;
   const ShaderProgramId progId = shaderManager.getProgram(shader_program_name);
   const std::vector<vk::PipelineShaderStageCreateInfo> shaderStages = shaderManager.getShaderStages(progId);
 
@@ -143,40 +141,13 @@ ComputePipeline PipelineManager::createComputePipeline(std::string shader_progra
       shaderManager.getProgramLayout(progId),
       shaderStages[0]));
   computePipelineParameters.emplace(pipelineId, ComputeParameters{progId, std::move(info)});
-  
+
   return ComputePipeline(this, pipelineId, progId);
 };
 
-static void print_prog_info(const etna::ShaderProgramInfo &info, const std::string &name)
-{
-  std::cout << "Program Info " << name << "\n";
-
-  for (uint32_t set = 0u; set < etna::MAX_PROGRAM_DESCRIPTORS; set++)
-  {
-    if (!info.isDescriptorSetUsed(set))
-      continue;
-    auto setInfo = info.getDescriptorSetInfo(set);
-    for (uint32_t binding = 0; binding < etna::MAX_DESCRIPTOR_BINDINGS; binding++)
-    {
-      if (!setInfo.isBindingUsed(binding))
-        continue;
-      auto &vkBinding = setInfo.getBinding(binding);
-
-      std::cout << "Binding " << binding << " " << vk::to_string(vkBinding.descriptorType) << ", count = " << vkBinding.descriptorCount << " ";
-      std::cout << " " << vk::to_string(vkBinding.stageFlags) << "\n"; 
-    }
-  }
-
-  auto pc = info.getPushConst();
-  if (pc.size)
-  {
-    std::cout << "PushConst " << " size = " << pc.size << " stages = " << vk::to_string(pc.stageFlags) << "\n";
-  }
-}
-
 GraphicsPipeline PipelineManager::createGraphicsPipeline(std::string shader_program_name, GraphicsPipeline::CreateInfo info)
 {
-  const PipelineId pipelineId = pipelineIdCounter++;  
+  const PipelineId pipelineId = pipelineIdCounter++;
   const ShaderProgramId progId = shaderManager.getProgram(shader_program_name);
 
   pipelines.emplace(pipelineId,
@@ -184,9 +155,11 @@ GraphicsPipeline PipelineManager::createGraphicsPipeline(std::string shader_prog
       shaderManager.getProgramLayout(progId),
       shaderManager.getShaderStages(progId), info));
   graphicsPipelineParameters.emplace(pipelineId, PipelineParameters{progId, std::move(info)});
-  
+
   GraphicsPipeline pipeline(this, pipelineId, progId);
-  print_prog_info(shaderManager.getProgramInfo(shader_program_name), shader_program_name);
+
+  shaderManager.logProgramInfo(shader_program_name);
+
   return pipeline;
 }
 
@@ -194,7 +167,7 @@ void PipelineManager::recreate()
 {
   pipelines.clear();
   for (const auto&[id, params] : graphicsPipelineParameters)
-    pipelines.emplace(id, 
+    pipelines.emplace(id,
       createGraphicsPipelineInternal(device,
         shaderManager.getProgramLayout(params.shaderProgram),
         shaderManager.getShaderStages(params.shaderProgram), params.info));
@@ -209,7 +182,7 @@ void PipelineManager::destroyPipeline(PipelineId id)
 {
   if (id == INVALID_PIPELINE_ID)
     return;
-  
+
   pipelines.erase(id);
   graphicsPipelineParameters.erase(id);
 }

--- a/etna/source/ShaderProgram.cpp
+++ b/etna/source/ShaderProgram.cpp
@@ -240,6 +240,36 @@ namespace etna
     progLayout = get_context().getDevice().createPipelineLayoutUnique(info).value;
   }
 
+  void ShaderProgramManager::logProgramInfo(const std::string& name) const
+  {
+    spdlog::info("Info for shader program '{}':", name);
+
+    auto info = getProgramInfo(name);
+
+    for (uint32_t set = 0u; set < etna::MAX_PROGRAM_DESCRIPTORS; set++)
+    {
+      if (!info.isDescriptorSetUsed(set))
+        continue;
+      auto setInfo = info.getDescriptorSetInfo(set);
+      for (uint32_t binding = 0; binding < etna::MAX_DESCRIPTOR_BINDINGS; binding++)
+      {
+        if (!setInfo.isBindingUsed(binding))
+          continue;
+        auto &vkBinding = setInfo.getBinding(binding);
+
+        spdlog::info("    Binding {}: type {}, stages {}, count {}",
+          binding, vk::to_string(vkBinding.descriptorType),
+          vkBinding.descriptorCount, vk::to_string(vkBinding.stageFlags));
+      }
+    }
+
+    auto pc = info.getPushConst();
+    if (pc.size)
+    {
+      spdlog::info("    Push constant block: size {}, stages {}", pc.size, vk::to_string(pc.stageFlags));
+    }
+  }
+
   void ShaderProgramManager::reloadPrograms()
   {
     for (auto &mod : shaderModules)

--- a/etna/source/ShaderProgram.cpp
+++ b/etna/source/ShaderProgram.cpp
@@ -96,14 +96,14 @@ namespace etna
 
   uint32_t ShaderProgramManager::registerModule(const std::filesystem::path& path)
   {
-    auto it = shaderModuleNames.find(path);
-    if (it != shaderModuleNames.end())
+    auto it = shaderModulePathToId.find(path);
+    if (it != shaderModulePathToId.end())
       return it->second;
 
     uint32_t modId = static_cast<uint32_t>(shaderModules.size());
 
     shaderModules.push_back(std::make_unique<ShaderModule>(vkDevice, path));
-    shaderModuleNames.emplace(std::pair{path, modId});
+    shaderModulePathToId.emplace(std::pair{path, modId});
 
     return modId;
   }
@@ -274,7 +274,7 @@ namespace etna
   {
     programNameToId.clear();
     programById.clear();
-    shaderModuleNames.clear();
+    shaderModulePathToId.clear();
     shaderModules.clear();
   }
 

--- a/etna/source/SpvReflectHelpers.hpp
+++ b/etna/source/SpvReflectHelpers.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <array>
+#include <spirv_reflect.h>
+#include <Assert.h>
+
+
+namespace etna
+{
+
+// Might break with updates of spir-v reflect, but unlikely
+constexpr std::array SPV_REFLECT_ERROR_CODE_STRINGS
+{
+    "SUCCESS",
+    "NOT_READY",
+    "ERROR_PARSE_FAILED",
+    "ERROR_ALLOC_FAILED",
+    "ERROR_RANGE_EXCEEDED",
+    "ERROR_NULL_POINTER",
+    "ERROR_INTERNAL_ERROR",
+    "ERROR_COUNT_MISMATCH",
+    "ERROR_ELEMENT_NOT_FOUND",
+    "ERROR_SPIRV_INVALID_CODE_SIZE",
+    "ERROR_SPIRV_INVALID_MAGIC_NUMBER",
+    "ERROR_SPIRV_UNEXPECTED_EOF",
+    "ERROR_SPIRV_INVALID_ID_REFERENCE",
+    "ERROR_SPIRV_SET_NUMBER_OVERFLOW",
+    "ERROR_SPIRV_INVALID_STORAGE_CLASS",
+    "ERROR_SPIRV_RECURSION",
+    "ERROR_SPIRV_INVALID_INSTRUCTION",
+    "ERROR_SPIRV_UNEXPECTED_BLOCK_DATA",
+    "ERROR_SPIRV_INVALID_BLOCK_MEMBER_REFERENCE",
+    "ERROR_SPIRV_INVALID_ENTRY_POINT",
+    "ERROR_SPIRV_INVALID_EXECUTION_MODE",
+};
+
+#define SPV_REFLECT_SAFE_CALL(call, file)\
+    do \
+    { \
+    auto errc = call; \
+    ETNA_ASSERTF(errc == SPV_REFLECT_RESULT_SUCCESS, \
+        "SPIR-V Reflect call {} failed with code {} for file {}!", \
+        #call, SPV_REFLECT_ERROR_CODE_STRINGS[errc], file); \
+    } \
+    while (false)
+
+static_assert(SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_EXECUTION_MODE == SPV_REFLECT_ERROR_CODE_STRINGS.size() - 1);
+
+}


### PR DESCRIPTION
- Use best post-modern C++ practices: view types in favour of const references (string_view, span, etc). Added a new StringMap alias for string_view-based lookup to work with unordered_map.
- For paths, replaced string with filesystem::path. It should theoretically support cyrillic characters.
- Removed trailing spaces in a bunch of places.
- Replaced old `if (xxx) ETNA_PANIC(...)` stuff with ETNA_ASSERT. Also replaced cout logging with spdlog logs.
- Flatten dependencies of ShaderProgramManager. Accessing stuff from GlobalContext within etna is a bad idea IMO, as that header includes basically all of etna, so compile times will get pretty bad pretty quickly. This approach also makes initialization and cleanup order less brittle, as the constructor explicitly takes all dependency references.