### PR TITLE
Return normal viewport and scissor dynamic states

### DIFF
--- a/etna/source/PipelineManager.cpp
+++ b/etna/source/PipelineManager.cpp
@@ -90,8 +90,8 @@ vk::UniquePipeline createGraphicsPipelineInternal(
   blendState.blendConstants = info.blendingConfig.blendConstants;
 
   std::vector<vk::DynamicState> dynamicStates = {
-    vk::DynamicState::eViewportWithCount,
-    vk::DynamicState::eScissorWithCount
+    vk::DynamicState::eViewport,
+    vk::DynamicState::eScissor
   };
   vk::PipelineDynamicStateCreateInfo dynamicState {};
   dynamicState.setDynamicStates(dynamicStates);


### PR DESCRIPTION
My previous changes to dynamic states were causing validation errors now that viewportCount and scissorCount are not 0.