### PR TITLE
Added flush_barriers function to Etna.hpp

### DIFF
--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -61,7 +61,7 @@ namespace etna
     vk::ImageLayout layout, vk::ImageAspectFlags aspect_flags);
 
   void finish_frame(vk::CommandBuffer com_buffer);
-
+  void flush_barriers(vk::CommandBuffer com_buffer);
 }
 
 #endif // ETNA_ETNA_HPP_INCLUDED

--- a/etna/source/Etna.cpp
+++ b/etna/source/Etna.cpp
@@ -79,4 +79,9 @@ namespace etna
   {
     etna::get_context().getResourceTracker().flushBarriers(com_buffer);
   }
+
+  void flush_barriers(vk::CommandBuffer com_buffer)
+  {
+    etna::get_context().getResourceTracker().flushBarriers(com_buffer);
+  }
 }

--- a/etna/source/PipelineManager.cpp
+++ b/etna/source/PipelineManager.cpp
@@ -90,8 +90,8 @@ vk::UniquePipeline createGraphicsPipelineInternal(
   blendState.blendConstants = info.blendingConfig.blendConstants;
 
   std::vector<vk::DynamicState> dynamicStates = {
-    vk::DynamicState::eViewportWithCount,
-    vk::DynamicState::eScissorWithCount
+    vk::DynamicState::eViewport,
+    vk::DynamicState::eScissor
   };
   vk::PipelineDynamicStateCreateInfo dynamicState {};
   dynamicState.setDynamicStates(dynamicStates);


### PR DESCRIPTION
Right now resource barriers are not automatically flushed before compute shader dispatch like happens with graphical pipelines, so this function allows for correct usage of etna::set_state with compute pipeline resources