### PR TITLE
Added more fields to AttachmentParams

### DIFF
--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -21,6 +21,10 @@ public:
         // TODO: Add new fields for clearing etc.
         vk::Image image = VK_NULL_HANDLE;
         vk::ImageView view = VK_NULL_HANDLE;
+        vk::AttachmentLoadOp loadOp = vk::AttachmentLoadOp::eClear;
+        vk::AttachmentStoreOp storeOp = vk::AttachmentStoreOp::eStore;
+        vk::ClearColorValue clearColorValue = std::array<float, 4>({0.0f, 0.0f, 0.0f, 1.0f});
+        vk::ClearDepthStencilValue clearDepthStencilValue = {1.0f, 0};
         AttachmentParams() = default;
         AttachmentParams(vk::Image i, vk::ImageView v) : image(i), view(v) {}
         AttachmentParams(const Image &img) : image(img.get()), view(img.getView({})) {}

--- a/etna/source/RenderTargetStates.cpp
+++ b/etna/source/RenderTargetStates.cpp
@@ -46,17 +46,17 @@ RenderTargetState::RenderTargetState(
   {
     attachmentInfos[i].imageView = color_attachments[i].view;
     attachmentInfos[i].imageLayout = vk::ImageLayout::eColorAttachmentOptimal;
-    attachmentInfos[i].loadOp = vk::AttachmentLoadOp::eClear;
-    attachmentInfos[i].storeOp = vk::AttachmentStoreOp::eStore;
-    attachmentInfos[i].clearValue = vk::ClearColorValue{std::array<float, 4>({0.0f, 0.0f, 0.0f, 1.0f})};
+    attachmentInfos[i].loadOp = color_attachments[i].loadOp;
+    attachmentInfos[i].storeOp = color_attachments[i].storeOp;
+    attachmentInfos[i].clearValue = color_attachments[i].clearColorValue;
     etna::get_context().getResourceTracker().setColorTarget(commandBuffer, color_attachments[i].image);
   }
   vk::RenderingAttachmentInfo depthAttInfo {
     .imageView = depth_attachment.view,
     .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
-    .loadOp = vk::AttachmentLoadOp::eClear,
-    .storeOp = vk::AttachmentStoreOp::eStore,
-    .clearValue = vk::ClearDepthStencilValue{1.0f, 0}
+    .loadOp = depth_attachment.loadOp,
+    .storeOp = depth_attachment.storeOp,
+    .clearValue = depth_attachment.clearDepthStencilValue
   };
   if (depth_attachment.image)
     etna::get_context().getResourceTracker().setDepthTarget(commandBuffer, depth_attachment.image);


### PR DESCRIPTION
Added loadOp, storeOp and clear values to AttachmentParams.
New usage with optional params:
```
  etna::RenderTargetState::AttachmentParams colorAttachmentParams{a_targetImage, a_targetImageView};
  colorAttachmentParams.loadOp = vk::AttachmentLoadOp::eDontCare;
  colorAttachmentParams.storeOp = vk::AttachmentStoreOp::eStore;
  etna::RenderTargetState renderTargets(a_cmdBuff, {m_width, m_height}, {colorAttachmentParams}, {});
```