### PR TITLE
Added ability to create images from bytes

### DIFF
--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -5,6 +5,7 @@
 #include <etna/Vulkan.hpp>
 #include <etna/ShaderProgram.hpp>
 #include <etna/DescriptorSet.hpp>
+#include <etna/Image.hpp>
 
 #include <optional>
 #include <vector>
@@ -13,8 +14,6 @@
 
 namespace etna
 {
-  class Image;
-
   struct InitParams
   {
     // Can be anything
@@ -55,6 +54,7 @@ namespace etna
 
   
   DescriptorSet create_descriptor_set(DescriptorLayoutId layout, vk::CommandBuffer command_buffer, std::vector<Binding> bindings);
+  Image create_image_from_bytes(Image::CreateInfo info, vk::CommandBuffer command_buffer, const void *data);
 
   void set_state(vk::CommandBuffer com_buffer, vk::Image image,
     vk::PipelineStageFlagBits2 pipeline_stage_flag, vk::AccessFlags2 access_flags,

--- a/etna/source/Etna.cpp
+++ b/etna/source/Etna.cpp
@@ -5,7 +5,6 @@
 #include <etna/GlobalContext.hpp>
 #include <etna/Etna.hpp>
 #include <vulkan/vulkan_format_traits.hpp>
-#include <vulkan/vulkan_funcs.hpp>
 
 
 namespace etna


### PR DESCRIPTION
Usage:
```
  etna::Image image = etna::create_image_from_bytes(etna::Image::CreateInfo
  {
    .extent = vk::Extent3D{4, 4, 1},
    .name = "my_image",
    .format = vk::Format::eR32G32B32A32Sfloat,
    .imageUsage = vk::ImageUsageFlagBits::eSampled
  }, m_cmdBufferAux, bytes.data());
```