### PR TITLE
gcc bug 88165 bypass

### DIFF
--- a/etna/include/etna/Image.hpp
+++ b/etna/include/etna/Image.hpp
@@ -51,7 +51,7 @@ public:
   };
   vk::ImageView getView(ViewParams params) const;
 
-  ImageBinding genBinding(vk::Sampler sampler, vk::ImageLayout layout, ViewParams params = {}) const;
+  ImageBinding genBinding(vk::Sampler sampler, vk::ImageLayout layout, ViewParams params = {0, 1}) const;
 
   vk::ImageAspectFlags getAspectMaskByFormat() const;
 


### PR DESCRIPTION
Обход бага gcc и clang https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165, из-за которого etna отказывается собираться