### PR TITLE
Rendertarget features

### DIFF
--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -13,33 +13,34 @@ namespace etna
 
 class RenderTargetState
 {
-    VkCommandBuffer commandBuffer;
-    static bool inScope;
+  VkCommandBuffer commandBuffer;
+  static bool inScope;
 public:
-    struct AttachmentParams
-    {
-        // TODO: Add new fields for clearing etc.
-        vk::Image image = VK_NULL_HANDLE;
-        vk::ImageView view = VK_NULL_HANDLE;
-        vk::AttachmentLoadOp loadOp = vk::AttachmentLoadOp::eClear;
-        vk::AttachmentStoreOp storeOp = vk::AttachmentStoreOp::eStore;
-        vk::ClearColorValue clearColorValue = std::array<float, 4>({0.0f, 0.0f, 0.0f, 1.0f});
-        vk::ClearDepthStencilValue clearDepthStencilValue = {1.0f, 0};
-        AttachmentParams() = default;
-        AttachmentParams(vk::Image i, vk::ImageView v) : image(i), view(v) {}
-        AttachmentParams(const Image &img) : image(img.get()), view(img.getView({})) {}
-    };
+  struct AttachmentParams
+  {
+    // TODO: Add new fields for clearing etc.
+    vk::Image image = VK_NULL_HANDLE;
+    vk::ImageView view = VK_NULL_HANDLE;
+    vk::AttachmentLoadOp loadOp = vk::AttachmentLoadOp::eClear;
+    vk::AttachmentStoreOp storeOp = vk::AttachmentStoreOp::eStore;
+    vk::ClearColorValue clearColorValue = std::array<float, 4>({0.0f, 0.0f, 0.0f, 1.0f});
+    vk::ClearDepthStencilValue clearDepthStencilValue = {1.0f, 0};
+    AttachmentParams() = default;
+    AttachmentParams(vk::Image i, vk::ImageView v) : image(i), view(v) {}
+    AttachmentParams(const Image &img) : image(img.get()), view(img.getView({})) {}
+  };
     
-    RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend,
-        const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment,
-        AttachmentParams stencil_attachment);
-    // We can't use the default argument for stencil_attachment due to gcc bug 88165
-    // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165
-    RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend, 
-        const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment) 
-        : RenderTargetState(cmd_buff, extend, color_attachments, depth_attachment, {}) {};
+  RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend,
+    const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment,
+    AttachmentParams stencil_attachment);
 
-    ~RenderTargetState();
+  // We can't use the default argument for stencil_attachment due to gcc bug 88165
+  // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165
+  RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend, 
+    const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment) 
+    : RenderTargetState(cmd_buff, extend, color_attachments, depth_attachment, {}) {};
+
+  ~RenderTargetState();
 };
 
 }

--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -31,7 +31,8 @@ public:
     };
     
     RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend,
-    const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment);
+        const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment,
+        AttachmentParams stencil_attachment);
     ~RenderTargetState();
 };
 

--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -35,8 +35,9 @@ public:
         AttachmentParams stencil_attachment);
     // We can't use the default argument for stencil_attachment due to gcc bug 88165
     // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165
-    RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend,
-        const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment);
+    RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend, 
+        const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment) 
+        : RenderTargetState(cmd_buff, extend, color_attachments, depth_attachment, {}) {};
 
     ~RenderTargetState();
 };

--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -33,6 +33,11 @@ public:
     RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend,
         const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment,
         AttachmentParams stencil_attachment);
+    // We can't use the default argument for stencil_attachment due to gcc bug 88165
+    // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165
+    RenderTargetState(VkCommandBuffer cmd_buff, vk::Extent2D extend,
+        const std::vector<AttachmentParams> &color_attachments, AttachmentParams depth_attachment);
+
     ~RenderTargetState();
 };
 

--- a/etna/source/RenderTargetStates.cpp
+++ b/etna/source/RenderTargetStates.cpp
@@ -15,15 +15,6 @@ RenderTargetState::RenderTargetState(
   VkCommandBuffer cmd_buff,
   vk::Extent2D extend,
   const std::vector<AttachmentParams> &color_attachments,
-  AttachmentParams depth_attachment)
-{
-  RenderTargetState(cmd_buff, extend, color_attachments, depth_attachment, {});
-}
-
-RenderTargetState::RenderTargetState(
-  VkCommandBuffer cmd_buff,
-  vk::Extent2D extend,
-  const std::vector<AttachmentParams> &color_attachments,
   AttachmentParams depth_attachment,
   AttachmentParams stencil_attachment)
 {

--- a/etna/source/RenderTargetStates.cpp
+++ b/etna/source/RenderTargetStates.cpp
@@ -15,6 +15,15 @@ RenderTargetState::RenderTargetState(
   VkCommandBuffer cmd_buff,
   vk::Extent2D extend,
   const std::vector<AttachmentParams> &color_attachments,
+  AttachmentParams depth_attachment)
+{
+  RenderTargetState(cmd_buff, extend, color_attachments, depth_attachment, {});
+}
+
+RenderTargetState::RenderTargetState(
+  VkCommandBuffer cmd_buff,
+  vk::Extent2D extend,
+  const std::vector<AttachmentParams> &color_attachments,
   AttachmentParams depth_attachment,
   AttachmentParams stencil_attachment)
 {
@@ -69,8 +78,9 @@ RenderTargetState::RenderTargetState(
     .clearValue = stencil_attachment.clearDepthStencilValue
   };
 
-  if (depth_attachment.image && depth_attachment.image == stencil_attachment.image)
+  if (depth_attachment.image && stencil_attachment.image)
   {
+    ETNA_ASSERTF(depth_attachment.view == stencil_attachment.view, "depth and stencil attachments must be created from the same image");
     etna::get_context().getResourceTracker().setDepthStencilTarget(commandBuffer, depth_attachment.image);
   }
   else

--- a/etna/source/RenderTargetStates.cpp
+++ b/etna/source/RenderTargetStates.cpp
@@ -15,7 +15,8 @@ RenderTargetState::RenderTargetState(
   VkCommandBuffer cmd_buff,
   vk::Extent2D extend,
   const std::vector<AttachmentParams> &color_attachments,
-  AttachmentParams depth_attachment)
+  AttachmentParams depth_attachment,
+  AttachmentParams stencil_attachment)
 {
   ETNA_ASSERTF(!inScope, "RenderTargetState scopes shouldn't overlap.");
   inScope = true;
@@ -51,6 +52,7 @@ RenderTargetState::RenderTargetState(
     attachmentInfos[i].clearValue = color_attachments[i].clearColorValue;
     etna::get_context().getResourceTracker().setColorTarget(commandBuffer, color_attachments[i].image);
   }
+
   vk::RenderingAttachmentInfo depthAttInfo {
     .imageView = depth_attachment.view,
     .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
@@ -58,8 +60,26 @@ RenderTargetState::RenderTargetState(
     .storeOp = depth_attachment.storeOp,
     .clearValue = depth_attachment.clearDepthStencilValue
   };
-  if (depth_attachment.image)
-    etna::get_context().getResourceTracker().setDepthTarget(commandBuffer, depth_attachment.image);
+  
+  vk::RenderingAttachmentInfo stencilAttInfo {
+    .imageView = stencil_attachment.view,
+    .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
+    .loadOp = stencil_attachment.loadOp,
+    .storeOp = stencil_attachment.storeOp,
+    .clearValue = stencil_attachment.clearDepthStencilValue
+  };
+
+  if (depth_attachment.image && depth_attachment.image == stencil_attachment.image)
+  {
+    etna::get_context().getResourceTracker().setDepthStencilTarget(commandBuffer, depth_attachment.image);
+  }
+  else
+  {
+    if (depth_attachment.image)
+      etna::get_context().getResourceTracker().setDepthTarget(commandBuffer, depth_attachment.image);
+    if (stencil_attachment.image)
+      etna::get_context().getResourceTracker().setStencilTarget(commandBuffer, stencil_attachment.image);
+  }
 
   etna::get_context().getResourceTracker().flushBarriers(commandBuffer);
 
@@ -68,7 +88,8 @@ RenderTargetState::RenderTargetState(
     .layerCount = 1,
     .colorAttachmentCount = static_cast<uint32_t>(attachmentInfos.size()),
     .pColorAttachments = attachmentInfos.size() ? attachmentInfos.data() : nullptr,
-    .pDepthAttachment = depth_attachment.view ? &depthAttInfo : nullptr
+    .pDepthAttachment = depth_attachment.view ? &depthAttInfo : nullptr,
+    .pStencilAttachment = stencil_attachment.view ? &stencilAttInfo : nullptr,
   };
   VkRenderingInfo rInf = (VkRenderingInfo)renderInfo;
   vkCmdBeginRendering(commandBuffer, &rInf);

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -72,6 +72,15 @@ void ResourceStates::setColorTarget(vk::CommandBuffer com_buffer, vk::Image imag
     vk::ImageAspectFlagBits::eColor);
 }
 
+void ResourceStates::setDepthStencilTarget(vk::CommandBuffer com_buffer, vk::Image image)
+{
+  setTextureState(com_buffer, image,
+    vk::PipelineStageFlagBits2::eEarlyFragmentTests,
+    vk::AccessFlagBits2::eDepthStencilAttachmentWrite,
+    vk::ImageLayout::eDepthStencilAttachmentOptimal,
+    vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil);
+}
+
 void ResourceStates::setDepthTarget(vk::CommandBuffer com_buffer, vk::Image image)
 {
   setTextureState(com_buffer, image,
@@ -79,6 +88,15 @@ void ResourceStates::setDepthTarget(vk::CommandBuffer com_buffer, vk::Image imag
     vk::AccessFlagBits2::eDepthStencilAttachmentWrite,
     vk::ImageLayout::eDepthStencilAttachmentOptimal,
     vk::ImageAspectFlagBits::eDepth);
+}
+
+void ResourceStates::setStencilTarget(vk::CommandBuffer com_buffer, vk::Image image)
+{
+  setTextureState(com_buffer, image,
+    vk::PipelineStageFlagBits2::eEarlyFragmentTests,
+    vk::AccessFlagBits2::eDepthStencilAttachmentWrite,
+    vk::ImageLayout::eDepthStencilAttachmentOptimal,
+    vk::ImageAspectFlagBits::eStencil);
 }
 
 }

--- a/etna/source/StateTracking.hpp
+++ b/etna/source/StateTracking.hpp
@@ -30,8 +30,10 @@ public:
     vk::ImageLayout layout, vk::ImageAspectFlags aspect_flags);
 
   void setColorTarget(vk::CommandBuffer com_buffer, vk::Image image);
+  void setDepthStencilTarget(vk::CommandBuffer com_buffer, vk::Image image);
   void setDepthTarget(vk::CommandBuffer com_buffer, vk::Image image);
-
+  void setStencilTarget(vk::CommandBuffer com_buffer, vk::Image image);
+  
   void flushBarriers(vk::CommandBuffer com_buf);
 };
 


### PR DESCRIPTION
1. Stencil attachment для rendertarget'а.
2.  Барьеры для использования depth и/или stencil. 
3. 3 if'а в конструкторе для возможности использовать либо весь VK_FORMAT_Dxx_SFLOAT_S8_UINT, либо только его depth или stencil часть, либо части от разных изображений (последнее само собой вышло, вряд ли так кто-то будет делать)