### PR TITLE
Render target state resolve

### DIFF
--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -33,35 +33,6 @@ public:
     vk::Image resolveImage = VK_NULL_HANDLE;
     vk::ImageView resolveImageView = VK_NULL_HANDLE;
     vk::ResolveModeFlagBits resolveMode = vk::ResolveModeFlagBits::eNone;
-<<<<<<< HEAD
-
-    AttachmentParams() = default;
-    AttachmentParams(vk::Image i, vk::ImageView v, bool clear = true)
-      : image(i)
-      , view(v)
-      , loadOp(clear ? vk::AttachmentLoadOp::eClear : vk::AttachmentLoadOp::eLoad)
-    {
-    }
-    explicit AttachmentParams(const Image& img, bool clear = true)
-      : AttachmentParams(img.get(), img.getView({}), clear)
-    {
-    }
-    AttachmentParams(vk::Image i, vk::ImageView v, vk::Image ri, vk::ImageView rv, bool clear = true, bool store = false)
-      : image(i)
-      , view(v)
-      , loadOp(clear ? vk::AttachmentLoadOp::eClear : vk::AttachmentLoadOp::eLoad)
-      , storeOp(store ? vk::AttachmentStoreOp::eStore : vk::AttachmentStoreOp::eDontCare)
-      , resolveImage(ri)
-      , resolveImageView(rv)
-      , resolveMode(vk::ResolveModeFlagBits::eAverage) 
-    {
-    }
-    AttachmentParams(const Image &img, const Image &res_img, bool clear = true, bool store = false) 
-      : AttachmentParams(img.get(), img.getView({}), res_img.get(), res_img.getView({}), clear, store)
-    {
-    }
-=======
->>>>>>> f6dfa1f (constructors removed, msaa comment added)
   };
 
   RenderTargetState(

--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -25,8 +25,8 @@ public:
     vk::AttachmentStoreOp storeOp = vk::AttachmentStoreOp::eStore;
     vk::ClearColorValue clearColorValue = std::array<float, 4>({0.0f, 0.0f, 0.0f, 1.0f});
     vk::ClearDepthStencilValue clearDepthStencilValue = {1.0f, 0};
-    
-    // By default, the render target can work with multisample images and pipelines, 
+
+    // By default, the render target can work with multisample images and pipelines,
     // but not produce a final single-sample result.
     // These fields below are for the final MSAA image.
     // Ignore unless you know what MSAA is and aren't sure you need it.

--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -19,7 +19,6 @@ class RenderTargetState
 public:
   struct AttachmentParams
   {
-    // TODO: Add new fields for clearing etc.
     vk::Image image = VK_NULL_HANDLE;
     vk::ImageView view = VK_NULL_HANDLE;
     vk::AttachmentLoadOp loadOp = vk::AttachmentLoadOp::eClear;
@@ -27,10 +26,14 @@ public:
     vk::ClearColorValue clearColorValue = std::array<float, 4>({0.0f, 0.0f, 0.0f, 1.0f});
     vk::ClearDepthStencilValue clearDepthStencilValue = {1.0f, 0};
     
-    // resolve part
+    // By default, the render target can work with multisample images and pipelines, 
+    // but not produce a final single-sample result.
+    // These fields below are for the final MSAA image.
+    // Ignore unless you know what MSAA is and aren't sure you need it.
     vk::Image resolveImage = VK_NULL_HANDLE;
     vk::ImageView resolveImageView = VK_NULL_HANDLE;
     vk::ResolveModeFlagBits resolveMode = vk::ResolveModeFlagBits::eNone;
+<<<<<<< HEAD
 
     AttachmentParams() = default;
     AttachmentParams(vk::Image i, vk::ImageView v, bool clear = true)
@@ -57,6 +60,8 @@ public:
       : AttachmentParams(img.get(), img.getView({}), res_img.get(), res_img.getView({}), clear, store)
     {
     }
+=======
+>>>>>>> f6dfa1f (constructors removed, msaa comment added)
   };
 
   RenderTargetState(

--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -26,6 +26,12 @@ public:
     vk::AttachmentStoreOp storeOp = vk::AttachmentStoreOp::eStore;
     vk::ClearColorValue clearColorValue = std::array<float, 4>({0.0f, 0.0f, 0.0f, 1.0f});
     vk::ClearDepthStencilValue clearDepthStencilValue = {1.0f, 0};
+    
+    // resolve part
+    vk::Image resolveImage = VK_NULL_HANDLE;
+    vk::ImageView resolveImageView = VK_NULL_HANDLE;
+    vk::ResolveModeFlagBits resolveMode = vk::ResolveModeFlagBits::eNone;
+
     AttachmentParams() = default;
     AttachmentParams(vk::Image i, vk::ImageView v, bool clear = true)
       : image(i)
@@ -35,6 +41,20 @@ public:
     }
     explicit AttachmentParams(const Image& img, bool clear = true)
       : AttachmentParams(img.get(), img.getView({}), clear)
+    {
+    }
+    AttachmentParams(vk::Image i, vk::ImageView v, vk::Image ri, vk::ImageView rv, bool clear = true, bool store = false)
+      : image(i)
+      , view(v)
+      , loadOp(clear ? vk::AttachmentLoadOp::eClear : vk::AttachmentLoadOp::eLoad)
+      , storeOp(store ? vk::AttachmentStoreOp::eStore : vk::AttachmentStoreOp::eDontCare)
+      , resolveImage(ri)
+      , resolveImageView(rv)
+      , resolveMode(vk::ResolveModeFlagBits::eAverage) 
+    {
+    }
+    AttachmentParams(const Image &img, const Image &res_img, bool clear = true, bool store = false) 
+      : AttachmentParams(img.get(), img.getView({}), res_img.get(), res_img.getView({}), clear, store)
     {
     }
   };

--- a/etna/source/RenderTargetStates.cpp
+++ b/etna/source/RenderTargetStates.cpp
@@ -42,10 +42,10 @@ RenderTargetState::RenderTargetState(
     attachmentInfos[i].loadOp = color_attachments[i].loadOp;
     attachmentInfos[i].storeOp = color_attachments[i].storeOp;
     attachmentInfos[i].clearValue = color_attachments[i].clearColorValue;
-    
+
     etna::get_context().getResourceTracker().setColorTarget(
       commandBuffer, color_attachments[i].image);
-    
+
     if (color_attachments[i].resolveImage)
     {
       etna::get_context().getResourceTracker().setResolveTarget(
@@ -86,7 +86,7 @@ RenderTargetState::RenderTargetState(
       "depth and stencil attachments must be created from the same image");
     etna::get_context().getResourceTracker().setDepthStencilTarget(
       commandBuffer, depth_attachment.image);
-    
+
     if (depth_attachment.resolveImage && stencil_attachment.resolveImage)
     {
       etna::get_context().getResourceTracker().setResolveTarget(
@@ -105,23 +105,19 @@ RenderTargetState::RenderTargetState(
       if (depth_attachment.resolveImage)
       {
         etna::get_context().getResourceTracker().setResolveTarget(
-          commandBuffer,
-          depth_attachment.resolveImage,
-          vk::ImageAspectFlagBits::eDepth);
+          commandBuffer, depth_attachment.resolveImage, vk::ImageAspectFlagBits::eDepth);
       }
     }
-    
+
     if (stencil_attachment.image)
     {
       etna::get_context().getResourceTracker().setStencilTarget(
         commandBuffer, stencil_attachment.image);
-      
+
       if (stencil_attachment.resolveImage)
       {
         etna::get_context().getResourceTracker().setResolveTarget(
-          commandBuffer,
-          stencil_attachment.resolveImage,
-          vk::ImageAspectFlagBits::eStencil);
+          commandBuffer, stencil_attachment.resolveImage, vk::ImageAspectFlagBits::eStencil);
       }
     }
   }

--- a/etna/source/RenderTargetStates.cpp
+++ b/etna/source/RenderTargetStates.cpp
@@ -51,7 +51,7 @@ RenderTargetState::RenderTargetState(
       etna::get_context().getResourceTracker().setResolveTarget(
         commandBuffer, color_attachments[i].resolveImage, vk::ImageAspectFlagBits::eColor);
 
-      attachmentInfos[i].resolveImageLayout = vk::ImageLayout::eTransferDstOptimal;
+      attachmentInfos[i].resolveImageLayout = vk::ImageLayout::eGeneral;
       attachmentInfos[i].resolveImageView = color_attachments[i].resolveImageView;
       attachmentInfos[i].resolveMode = color_attachments[i].resolveMode;
     }
@@ -62,7 +62,7 @@ RenderTargetState::RenderTargetState(
     .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
     .resolveMode = depth_attachment.resolveMode,
     .resolveImageView = depth_attachment.resolveImageView,
-    .resolveImageLayout = vk::ImageLayout::eTransferDstOptimal,
+    .resolveImageLayout = vk::ImageLayout::eGeneral,
     .loadOp = depth_attachment.loadOp,
     .storeOp = depth_attachment.storeOp,
     .clearValue = depth_attachment.clearDepthStencilValue,
@@ -73,7 +73,7 @@ RenderTargetState::RenderTargetState(
     .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
     .resolveMode = stencil_attachment.resolveMode,
     .resolveImageView = stencil_attachment.resolveImageView,
-    .resolveImageLayout = vk::ImageLayout::eTransferDstOptimal,
+    .resolveImageLayout = vk::ImageLayout::eGeneral,
     .loadOp = stencil_attachment.loadOp,
     .storeOp = stencil_attachment.storeOp,
     .clearValue = stencil_attachment.clearDepthStencilValue,

--- a/etna/source/RenderTargetStates.cpp
+++ b/etna/source/RenderTargetStates.cpp
@@ -42,13 +42,27 @@ RenderTargetState::RenderTargetState(
     attachmentInfos[i].loadOp = color_attachments[i].loadOp;
     attachmentInfos[i].storeOp = color_attachments[i].storeOp;
     attachmentInfos[i].clearValue = color_attachments[i].clearColorValue;
+    
     etna::get_context().getResourceTracker().setColorTarget(
       commandBuffer, color_attachments[i].image);
+    
+    if (color_attachments[i].resolveImage)
+    {
+      etna::get_context().getResourceTracker().setResolveTarget(
+        commandBuffer, color_attachments[i].resolveImage, vk::ImageAspectFlagBits::eColor);
+
+      attachmentInfos[i].resolveImageLayout = vk::ImageLayout::eTransferDstOptimal;
+      attachmentInfos[i].resolveImageView = color_attachments[i].resolveImageView;
+      attachmentInfos[i].resolveMode = color_attachments[i].resolveMode;
+    }
   }
 
   vk::RenderingAttachmentInfo depthAttInfo{
     .imageView = depth_attachment.view,
     .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
+    .resolveMode = depth_attachment.resolveMode,
+    .resolveImageView = depth_attachment.resolveImageView,
+    .resolveImageLayout = vk::ImageLayout::eTransferDstOptimal,
     .loadOp = depth_attachment.loadOp,
     .storeOp = depth_attachment.storeOp,
     .clearValue = depth_attachment.clearDepthStencilValue,
@@ -57,6 +71,9 @@ RenderTargetState::RenderTargetState(
   vk::RenderingAttachmentInfo stencilAttInfo{
     .imageView = stencil_attachment.view,
     .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
+    .resolveMode = stencil_attachment.resolveMode,
+    .resolveImageView = stencil_attachment.resolveImageView,
+    .resolveImageLayout = vk::ImageLayout::eTransferDstOptimal,
     .loadOp = stencil_attachment.loadOp,
     .storeOp = stencil_attachment.storeOp,
     .clearValue = stencil_attachment.clearDepthStencilValue,
@@ -69,15 +86,44 @@ RenderTargetState::RenderTargetState(
       "depth and stencil attachments must be created from the same image");
     etna::get_context().getResourceTracker().setDepthStencilTarget(
       commandBuffer, depth_attachment.image);
+    
+    if (depth_attachment.resolveImage && stencil_attachment.resolveImage)
+    {
+      etna::get_context().getResourceTracker().setResolveTarget(
+        commandBuffer,
+        depth_attachment.resolveImage,
+        vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil);
+    }
   }
   else
   {
     if (depth_attachment.image)
+    {
       etna::get_context().getResourceTracker().setDepthTarget(
         commandBuffer, depth_attachment.image);
+
+      if (depth_attachment.resolveImage)
+      {
+        etna::get_context().getResourceTracker().setResolveTarget(
+          commandBuffer,
+          depth_attachment.resolveImage,
+          vk::ImageAspectFlagBits::eDepth);
+      }
+    }
+    
     if (stencil_attachment.image)
+    {
       etna::get_context().getResourceTracker().setStencilTarget(
         commandBuffer, stencil_attachment.image);
+      
+      if (stencil_attachment.resolveImage)
+      {
+        etna::get_context().getResourceTracker().setResolveTarget(
+          commandBuffer,
+          stencil_attachment.resolveImage,
+          vk::ImageAspectFlagBits::eStencil);
+      }
+    }
   }
 
   etna::get_context().getResourceTracker().flushBarriers(commandBuffer);

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -116,7 +116,7 @@ void ResourceStates::setResolveTarget(
     image,
     vk::PipelineStageFlagBits2::eResolve,
     vk::AccessFlagBits2::eTransferWrite,
-    vk::ImageLayout::eTransferDstOptimal,
+    vk::ImageLayout::eGeneral,
     aspect_flags);
 }
 

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -106,4 +106,18 @@ void ResourceStates::setStencilTarget(vk::CommandBuffer com_buffer, vk::Image im
     vk::ImageAspectFlagBits::eStencil);
 }
 
+void ResourceStates::setResolveTarget(
+  vk::CommandBuffer com_buffer,
+  vk::Image image,
+  vk::ImageAspectFlags aspect_flags)
+{
+  setTextureState(
+    com_buffer,
+    image,
+    vk::PipelineStageFlagBits2::eResolve,
+    vk::AccessFlagBits2::eTransferWrite,
+    vk::ImageLayout::eTransferDstOptimal,
+    aspect_flags);
+}
+
 } // namespace etna

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -107,9 +107,7 @@ void ResourceStates::setStencilTarget(vk::CommandBuffer com_buffer, vk::Image im
 }
 
 void ResourceStates::setResolveTarget(
-  vk::CommandBuffer com_buffer,
-  vk::Image image,
-  vk::ImageAspectFlags aspect_flags)
+  vk::CommandBuffer com_buffer, vk::Image image, vk::ImageAspectFlags aspect_flags)
 {
   setTextureState(
     com_buffer,

--- a/etna/source/StateTracking.hpp
+++ b/etna/source/StateTracking.hpp
@@ -38,6 +38,10 @@ public:
   void setDepthStencilTarget(vk::CommandBuffer com_buffer, vk::Image image);
   void setDepthTarget(vk::CommandBuffer com_buffer, vk::Image image);
   void setStencilTarget(vk::CommandBuffer com_buffer, vk::Image image);
+  void setResolveTarget(
+    vk::CommandBuffer com_buffer,
+    vk::Image image,
+    vk::ImageAspectFlags aspect_flags);
 
   void flushBarriers(vk::CommandBuffer com_buf);
 };

--- a/etna/source/StateTracking.hpp
+++ b/etna/source/StateTracking.hpp
@@ -39,9 +39,7 @@ public:
   void setDepthTarget(vk::CommandBuffer com_buffer, vk::Image image);
   void setStencilTarget(vk::CommandBuffer com_buffer, vk::Image image);
   void setResolveTarget(
-    vk::CommandBuffer com_buffer,
-    vk::Image image,
-    vk::ImageAspectFlags aspect_flags);
+    vk::CommandBuffer com_buffer, vk::Image image, vk::ImageAspectFlags aspect_flags);
 
   void flushBarriers(vk::CommandBuffer com_buf);
 };


### PR DESCRIPTION
+3 поля в attachment
+2 соответствующих конструктора для attachment
+1 барьер для resolve изображения перед отрисовкой (обратный барьер на совести пользователя)
 