### PR TITLE
barrier fixes

### DIFF
--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -21,6 +21,7 @@ public:
   {
     vk::Image image = VK_NULL_HANDLE;
     vk::ImageView view = VK_NULL_HANDLE;
+    std::optional<vk::ImageAspectFlags> imageAspect{};
     vk::AttachmentLoadOp loadOp = vk::AttachmentLoadOp::eClear;
     vk::AttachmentStoreOp storeOp = vk::AttachmentStoreOp::eStore;
     vk::ClearColorValue clearColorValue = std::array<float, 4>({0.0f, 0.0f, 0.0f, 1.0f});
@@ -32,6 +33,7 @@ public:
     // Ignore unless you know what MSAA is and aren't sure you need it.
     vk::Image resolveImage = VK_NULL_HANDLE;
     vk::ImageView resolveImageView = VK_NULL_HANDLE;
+    std::optional<vk::ImageAspectFlags> resolveImageAspect{};
     vk::ResolveModeFlagBits resolveMode = vk::ResolveModeFlagBits::eNone;
   };
 

--- a/etna/source/RenderTargetStates.cpp
+++ b/etna/source/RenderTargetStates.cpp
@@ -85,7 +85,9 @@ RenderTargetState::RenderTargetState(
       depth_attachment.view == stencil_attachment.view,
       "depth and stencil attachments must be created from the same image");
     etna::get_context().getResourceTracker().setDepthStencilTarget(
-      commandBuffer, depth_attachment.image);
+      commandBuffer,
+      depth_attachment.image,
+      vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil);
 
     if (depth_attachment.resolveImage && stencil_attachment.resolveImage)
     {
@@ -99,25 +101,33 @@ RenderTargetState::RenderTargetState(
   {
     if (depth_attachment.image)
     {
-      etna::get_context().getResourceTracker().setDepthTarget(
-        commandBuffer, depth_attachment.image);
+      etna::get_context().getResourceTracker().setDepthStencilTarget(
+        commandBuffer,
+        depth_attachment.image,
+        depth_attachment.imageAspect.value_or(vk::ImageAspectFlagBits::eDepth));
 
       if (depth_attachment.resolveImage)
       {
         etna::get_context().getResourceTracker().setResolveTarget(
-          commandBuffer, depth_attachment.resolveImage, vk::ImageAspectFlagBits::eDepth);
+          commandBuffer,
+          depth_attachment.resolveImage,
+          depth_attachment.resolveImageAspect.value_or(vk::ImageAspectFlagBits::eDepth));
       }
     }
 
     if (stencil_attachment.image)
     {
-      etna::get_context().getResourceTracker().setStencilTarget(
-        commandBuffer, stencil_attachment.image);
+      etna::get_context().getResourceTracker().setDepthStencilTarget(
+        commandBuffer,
+        stencil_attachment.image,
+        stencil_attachment.imageAspect.value_or(vk::ImageAspectFlagBits::eStencil));
 
       if (stencil_attachment.resolveImage)
       {
         etna::get_context().getResourceTracker().setResolveTarget(
-          commandBuffer, stencil_attachment.resolveImage, vk::ImageAspectFlagBits::eStencil);
+          commandBuffer,
+          stencil_attachment.resolveImage,
+          stencil_attachment.resolveImageAspect.value_or(vk::ImageAspectFlagBits::eStencil));
       }
     }
   }

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -73,7 +73,8 @@ void ResourceStates::setColorTarget(vk::CommandBuffer com_buffer, vk::Image imag
     vk::ImageAspectFlagBits::eColor);
 }
 
-void ResourceStates::setDepthStencilTarget(vk::CommandBuffer com_buffer, vk::Image image)
+void ResourceStates::setDepthStencilTarget(
+  vk::CommandBuffer com_buffer, vk::Image image, vk::ImageAspectFlags aspect_flags)
 {
   setTextureState(
     com_buffer,
@@ -81,29 +82,7 @@ void ResourceStates::setDepthStencilTarget(vk::CommandBuffer com_buffer, vk::Ima
     vk::PipelineStageFlagBits2::eEarlyFragmentTests,
     vk::AccessFlagBits2::eDepthStencilAttachmentWrite,
     vk::ImageLayout::eDepthStencilAttachmentOptimal,
-    vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil);
-}
-
-void ResourceStates::setDepthTarget(vk::CommandBuffer com_buffer, vk::Image image)
-{
-  setTextureState(
-    com_buffer,
-    image,
-    vk::PipelineStageFlagBits2::eEarlyFragmentTests,
-    vk::AccessFlagBits2::eDepthStencilAttachmentWrite,
-    vk::ImageLayout::eDepthStencilAttachmentOptimal,
-    vk::ImageAspectFlagBits::eDepth);
-}
-
-void ResourceStates::setStencilTarget(vk::CommandBuffer com_buffer, vk::Image image)
-{
-  setTextureState(
-    com_buffer,
-    image,
-    vk::PipelineStageFlagBits2::eEarlyFragmentTests,
-    vk::AccessFlagBits2::eDepthStencilAttachmentWrite,
-    vk::ImageLayout::eDepthStencilAttachmentOptimal,
-    vk::ImageAspectFlagBits::eStencil);
+    aspect_flags);
 }
 
 void ResourceStates::setResolveTarget(

--- a/etna/source/StateTracking.hpp
+++ b/etna/source/StateTracking.hpp
@@ -35,9 +35,8 @@ public:
     vk::ImageAspectFlags aspect_flags);
 
   void setColorTarget(vk::CommandBuffer com_buffer, vk::Image image);
-  void setDepthStencilTarget(vk::CommandBuffer com_buffer, vk::Image image);
-  void setDepthTarget(vk::CommandBuffer com_buffer, vk::Image image);
-  void setStencilTarget(vk::CommandBuffer com_buffer, vk::Image image);
+  void setDepthStencilTarget(
+    vk::CommandBuffer com_buffer, vk::Image image, vk::ImageAspectFlags aspect_flags);
   void setResolveTarget(
     vk::CommandBuffer com_buffer, vk::Image image, vk::ImageAspectFlags aspect_flags);
 


### PR DESCRIPTION
Опциональные поля vk::ImageAspectFlags нужны для depthStencil изображений. Если изображение имеет и глубину, и трафарет, но мы хотим использовать что-то одно в проходе. то надо либо включать раздельные барьеры, либо указать дополнительное поле imageAspect = eDepth | eStencil