### PR TITLE
fix command buffer submit info

### DIFF
--- a/etna/source/PerFrameCmdMgr.cpp
+++ b/etna/source/PerFrameCmdMgr.cpp
@@ -60,7 +60,7 @@ vk::Semaphore PerFrameCmdMgr::submit(vk::CommandBuffer what, vk::Semaphore write
   std::array wait{vk::SemaphoreSubmitInfo{
     .semaphore = write_attachments_after,
     .stageMask = vk::PipelineStageFlagBits2::eColorAttachmentOutput,
-    .deviceIndex = 1,
+    .deviceIndex = 0,
   }};
 
   // NOTE: this is intended to be used for presenting, and as far
@@ -70,7 +70,7 @@ vk::Semaphore PerFrameCmdMgr::submit(vk::CommandBuffer what, vk::Semaphore write
   std::array signal{vk::SemaphoreSubmitInfo{
     .semaphore = gpuDone.get(),
     .stageMask = {},
-    .deviceIndex = 1,
+    .deviceIndex = 0,
   }};
 
   vk::SubmitInfo2 sInfo{};


### PR DESCRIPTION
Idk how it works on other GPUs,
but my AMD card refuses to understand who is this 'deviceIndex=1'.

Since etna is a training framework,
I don't think it makes sense to write logic to select the required device in a group