### PR TITLE
Add MacOS support and improve validation initialization

### DIFF
--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -15,6 +15,12 @@
 namespace etna
 {
 
+enum class ValidationLevel : uint32_t
+{
+  eBasic,
+  eExtensive
+};
+
 struct InitParams
 {
   /// Can be anything
@@ -34,6 +40,9 @@ struct InitParams
 
   /// How much do we allow the CPU to "outrun" the GPU asynchronously
   uint32_t numFramesInFlight = 2;
+
+  /// How extensive the validation should be. The more extensive the more overhead validation has!
+  ValidationLevel validationLevel = ValidationLevel::eBasic;
 };
 
 bool is_initilized();

--- a/etna/include/etna/EtnaConfig.hpp
+++ b/etna/include/etna/EtnaConfig.hpp
@@ -9,11 +9,14 @@ namespace etna
 {
 
 #if NDEBUG
-inline constexpr std::array<const char*, 0> VALIDATION_LAYERS = {};
+inline constexpr std::array<const char*, 0> VULKAN_LAYERS = {};
 #else
-inline constexpr std::array VALIDATION_LAYERS = {
+inline constexpr std::array VULKAN_LAYERS = {
   "VK_LAYER_KHRONOS_validation",
-  "VK_LAYER_LUNARG_monitor",
+
+#if !defined(__APPLE__)
+  "VK_LAYER_LUNARG_monitor"
+#endif
 };
 #endif
 

--- a/etna/include/etna/Vulkan.hpp
+++ b/etna/include/etna/Vulkan.hpp
@@ -23,6 +23,12 @@
 #endif
 #define WIN32_LEAN_AND_MEAN
 #endif
+
+// Need to enable beta extensions for VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME to be declared
+#if defined(__APPLE__)
+#define VK_ENABLE_BETA_EXTENSIONS
+#endif
+
 #include <vulkan/vulkan.hpp>
 
 #define ETNA_CHECK_VK_RESULT(expr)                                                                 \

--- a/etna/source/DebugUtils.cpp
+++ b/etna/source/DebugUtils.cpp
@@ -32,7 +32,7 @@ static void set_debug_name_base(
 }
 #else
 template <class T>
-static void set_debug_name_base(T, vk::DebugReportObjectTypeEXT, const char*)
+static void set_debug_name_base(T, vk::ObjectType, const char*)
 {
 }
 #endif

--- a/etna/source/DebugUtils.cpp
+++ b/etna/source/DebugUtils.cpp
@@ -9,20 +9,22 @@
 namespace etna
 {
 
+// NOTE: Previously we used VK_EXT_debug_marker extension,
+// but it is considered to be abandoned in favour of VK_EXT_debug_utils.
 #ifdef ETNA_SET_VULKAN_DEBUG_NAMES
 template <class T>
 static void set_debug_name_base(
-  T object, vk::DebugReportObjectTypeEXT object_type, const char* name)
+  T object, vk::ObjectType object_type, const char* name)
 {
   const auto nativeHandle = static_cast<typename std::remove_cvref_t<T>::NativeType>(object);
   // The NativeType for a vulkan object can either be a uint64_t,
   // or an opaque pointer, hence we need a bit case.
-  vk::DebugMarkerObjectNameInfoEXT debugNameInfo = {
+  vk::DebugUtilsObjectNameInfoEXT debugNameInfo = {
     .objectType = object_type,
-    .object = std::bit_cast<uint64_t>(nativeHandle),
+    .objectHandle = std::bit_cast<uint64_t>(nativeHandle),
     .pObjectName = name,
   };
-  auto retcode = etna::get_context().getDevice().debugMarkerSetObjectNameEXT(&debugNameInfo);
+  auto retcode = etna::get_context().getDevice().setDebugUtilsObjectNameEXT(&debugNameInfo);
   ETNA_VERIFYF(
     retcode == vk::Result::eSuccess,
     "Error {} occurred while trying to set a debug name!",
@@ -37,17 +39,17 @@ static void set_debug_name_base(T, vk::DebugReportObjectTypeEXT, const char*)
 
 void set_debug_name(vk::Image image, const char* name)
 {
-  set_debug_name_base(image, vk::DebugReportObjectTypeEXT::eImage, name);
+  set_debug_name_base(image, vk::ObjectType::eImage, name);
 }
 
 void set_debug_name(vk::Buffer buffer, const char* name)
 {
-  set_debug_name_base(buffer, vk::DebugReportObjectTypeEXT::eBuffer, name);
+  set_debug_name_base(buffer, vk::ObjectType::eBuffer, name);
 }
 
 void set_debug_name(vk::Sampler sampler, const char* name)
 {
-  set_debug_name_base(sampler, vk::DebugReportObjectTypeEXT::eSampler, name);
+  set_debug_name_base(sampler, vk::ObjectType::eSampler, name);
 }
 
 } // namespace etna

--- a/etna/source/DebugUtils.cpp
+++ b/etna/source/DebugUtils.cpp
@@ -13,8 +13,7 @@ namespace etna
 // but it is considered to be abandoned in favour of VK_EXT_debug_utils.
 #ifdef ETNA_SET_VULKAN_DEBUG_NAMES
 template <class T>
-static void set_debug_name_base(
-  T object, vk::ObjectType object_type, const char* name)
+static void set_debug_name_base(T object, vk::ObjectType object_type, const char* name)
 {
   const auto nativeHandle = static_cast<typename std::remove_cvref_t<T>::NativeType>(object);
   // The NativeType for a vulkan object can either be a uint64_t,

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -28,9 +28,11 @@ static const void* getExtraValidation()
     vk::ValidationFeatureEnableEXT::eBestPractices,
     vk::ValidationFeatureEnableEXT::eSynchronizationValidation};
 
+#if defined(__APPLE__)
   static constexpr vk::ValidationFeatureDisableEXT APPLE_DISABLE_FEATURES[] = {
     vk::ValidationFeatureDisableEXT::eShaders,
     vk::ValidationFeatureDisableEXT::eShaderValidationCache};
+#endif
 
   static constexpr vk::ValidationFeaturesEXT FEATURES_INFO
   {

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -21,6 +21,46 @@
 namespace etna
 {
 
+static const void* getExtraValidation()
+{
+  // NOTE: Turn on shader access synchronization validation, which is disabled by default
+  // in newest versions of validation layers.
+  // For more info see https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8467
+  constexpr static VkBool32 ACTIVATE_SHADER_SYNC = VK_TRUE;
+  constexpr static VkLayerSettingEXT SETTING_SHADER_ACCESS_SYNC_VALIDATE{
+    .pLayerName = "VK_LAYER_KHRONOS_validation",
+    .pSettingName = "syncval_shader_accesses_heuristic",
+    .type = VK_LAYER_SETTING_TYPE_BOOL32_EXT,
+    .valueCount = 1U,
+    .pValues = &ACTIVATE_SHADER_SYNC
+  };
+
+  static constexpr vk::ValidationFeatureEnableEXT EXTRA_FEATURES[] = {
+    vk::ValidationFeatureEnableEXT::eGpuAssisted,
+    vk::ValidationFeatureEnableEXT::eBestPractices,
+    vk::ValidationFeatureEnableEXT::eSynchronizationValidation
+  };
+
+  static constexpr vk::ValidationFeatureDisableEXT DISABLE_EXTRA_FEATURES[] = {
+    vk::ValidationFeatureDisableEXT::eShaders,
+    vk::ValidationFeatureDisableEXT::eShaderValidationCache
+  };
+
+  static constexpr vk::ValidationFeaturesEXT FEATURES_INFO{
+    .pNext = &SETTING_SHADER_ACCESS_SYNC_VALIDATE,
+
+    .enabledValidationFeatureCount = std::size(EXTRA_FEATURES),
+    .pEnabledValidationFeatures = EXTRA_FEATURES,
+
+#if defined(__APPLE__)
+    .disabledValidationFeatureCount = std::size(DISABLE_EXTRA_FEATURES),
+    .pDisabledValidationFeatures = DISABLE_EXTRA_FEATURES
+#endif
+  };
+
+  return &FEATURES_INFO;
+}
+
 static vk::UniqueInstance createInstance(const InitParams& params)
 {
   vk::ApplicationInfo appInfo{
@@ -34,19 +74,27 @@ static vk::UniqueInstance createInstance(const InitParams& params)
   std::vector<const char*> extensions(
     params.instanceExtensions.begin(), params.instanceExtensions.end());
   extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+  extensions.push_back(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
 
-  std::vector<const char*> layers(VALIDATION_LAYERS.begin(), VALIDATION_LAYERS.end());
-  // Compatibility layer for devices that do not implement this extension natively.
-  // Sync2 provides potential for driver optimization and a saner programmer API,
-  // but is able to be translated into old synchronization calls if needed.
-  layers.push_back("VK_LAYER_KHRONOS_synchronization2");
+  // NOTE: Extension for the vulkan loader to list non-conformant implementations, such as
+  // for example MoltenVK on Apple devices.
+  extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+
+  std::vector<const char*> layers(VULKAN_LAYERS.begin(), VULKAN_LAYERS.end());
 
   vk::InstanceCreateInfo createInfo{
     .pApplicationInfo = &appInfo,
   };
 
+  // NOTE: Enable non-conformant Vulkan implementations.
+  createInfo.setFlags(vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR);
+
   createInfo.setPEnabledLayerNames(layers);
   createInfo.setPEnabledExtensionNames(extensions);
+
+  if (params.validationLevel == ValidationLevel::eExtensive) {
+    createInfo.setPNext(getExtraValidation());
+  }
 
   return unwrap_vk_result(vk::createInstanceUnique(createInfo));
 }
@@ -184,10 +232,16 @@ static vk::UniqueDevice createDevice(
   std::vector<char const*> deviceExtensions(
     params.deviceExtensions.begin(), params.deviceExtensions.end());
   deviceExtensions.push_back(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-#ifdef ETNA_SET_VULKAN_DEBUG_NAMES
-  deviceExtensions.push_back(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+
+  // NOTE: These extensions are needed on MoltenVK to be set explicitly due to
+  // it not fully supporting Vulkan 1.3 yet.
+#if defined(__APPLE__)
+  deviceExtensions.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+  deviceExtensions.push_back(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
 #endif
 
+  // NOTE: Enable non-conformant Vulkan implementations.
+  deviceExtensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
   // NOTE: original design of PhysicalDeviceFeatures did not
   // support extensions, so they had to use a trick to achieve

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -78,7 +78,9 @@ static vk::UniqueInstance createInstance(const InitParams& params)
 
   // NOTE: Extension for the vulkan loader to list non-conformant implementations, such as
   // for example MoltenVK on Apple devices.
+#if defined(__APPLE__)
   extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+#endif
 
   std::vector<const char*> layers(VULKAN_LAYERS.begin(), VULKAN_LAYERS.end());
 
@@ -87,7 +89,9 @@ static vk::UniqueInstance createInstance(const InitParams& params)
   };
 
   // NOTE: Enable non-conformant Vulkan implementations.
+#if defined(__APPLE__)
   createInfo.setFlags(vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR);
+#endif
 
   createInfo.setPEnabledLayerNames(layers);
   createInfo.setPEnabledExtensionNames(extensions);
@@ -241,7 +245,9 @@ static vk::UniqueDevice createDevice(
 #endif
 
   // NOTE: Enable non-conformant Vulkan implementations.
+#if defined(__APPLE__)
   deviceExtensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+#endif
 
   // NOTE: original design of PhysicalDeviceFeatures did not
   // support extensions, so they had to use a trick to achieve

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -23,38 +23,22 @@ namespace etna
 
 static const void* getExtraValidation()
 {
-  // NOTE: Turn on shader access synchronization validation, which is disabled by default
-  // in newest versions of validation layers.
-  // For more info see https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8467
-  constexpr static VkBool32 ACTIVATE_SHADER_SYNC = VK_TRUE;
-  constexpr static VkLayerSettingEXT SETTING_SHADER_ACCESS_SYNC_VALIDATE{
-    .pLayerName = "VK_LAYER_KHRONOS_validation",
-    .pSettingName = "syncval_shader_accesses_heuristic",
-    .type = VK_LAYER_SETTING_TYPE_BOOL32_EXT,
-    .valueCount = 1U,
-    .pValues = &ACTIVATE_SHADER_SYNC
-  };
-
   static constexpr vk::ValidationFeatureEnableEXT EXTRA_FEATURES[] = {
     vk::ValidationFeatureEnableEXT::eGpuAssisted,
     vk::ValidationFeatureEnableEXT::eBestPractices,
-    vk::ValidationFeatureEnableEXT::eSynchronizationValidation
-  };
+    vk::ValidationFeatureEnableEXT::eSynchronizationValidation};
 
-  static constexpr vk::ValidationFeatureDisableEXT DISABLE_EXTRA_FEATURES[] = {
+  static constexpr vk::ValidationFeatureDisableEXT APPLE_DISABLE_FEATURES[] = {
     vk::ValidationFeatureDisableEXT::eShaders,
-    vk::ValidationFeatureDisableEXT::eShaderValidationCache
-  };
+    vk::ValidationFeatureDisableEXT::eShaderValidationCache};
 
   static constexpr vk::ValidationFeaturesEXT FEATURES_INFO{
-    .pNext = &SETTING_SHADER_ACCESS_SYNC_VALIDATE,
-
     .enabledValidationFeatureCount = std::size(EXTRA_FEATURES),
     .pEnabledValidationFeatures = EXTRA_FEATURES,
 
 #if defined(__APPLE__)
-    .disabledValidationFeatureCount = std::size(DISABLE_EXTRA_FEATURES),
-    .pDisabledValidationFeatures = DISABLE_EXTRA_FEATURES
+    .disabledValidationFeatureCount = std::size(APPLE_DISABLE_FEATURES),
+    .pDisabledValidationFeatures = APPLE_DISABLE_FEATURES
 #endif
   };
 
@@ -96,7 +80,8 @@ static vk::UniqueInstance createInstance(const InitParams& params)
   createInfo.setPEnabledLayerNames(layers);
   createInfo.setPEnabledExtensionNames(extensions);
 
-  if (params.validationLevel == ValidationLevel::eExtensive) {
+  if (params.validationLevel == ValidationLevel::eExtensive)
+  {
     createInfo.setPNext(getExtraValidation());
   }
 

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -32,7 +32,8 @@ static const void* getExtraValidation()
     vk::ValidationFeatureDisableEXT::eShaders,
     vk::ValidationFeatureDisableEXT::eShaderValidationCache};
 
-  static constexpr vk::ValidationFeaturesEXT FEATURES_INFO{
+  static constexpr vk::ValidationFeaturesEXT FEATURES_INFO
+  {
     .enabledValidationFeatureCount = std::size(EXTRA_FEATURES),
     .pEnabledValidationFeatures = EXTRA_FEATURES,
 


### PR DESCRIPTION
# Changes
- Add support for MacOS (via MoltenVK).
- Add more extensive validation option (see [VkValidationFeatureEnableEXT](https://registry.khronos.org/VulkanSC/specs/1.0-extensions/man/html/VkValidationFeatureEnableEXT.html)) enabling:
    - VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT: "specifies that GPU-assisted validation is enabled. Activating this feature instruments shader programs to generate additional diagnostic data"
    - VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT: "specifies that Vulkan best-practices validation is enabled. Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification"
    - VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT: "specifies that Vulkan synchronization validation is enabled. This feature reports resource access conflicts due to missing or incorrect synchronization operations between actions (Draw, Copy, Dispatch, Blit) reading or writing the same regions of memory"
- Upgrade debug markers usage from [VK_EXT_debug_marker](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_debug_marker.html) (a _device_ extension) to [VK_EXT_debug_utils](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_debug_utils.html) (an _instance_ extension). The latter is already being requested by etna, so there's no need for the prior one. For VK_EXT_debug_marker, the spec states under _Deprecation State_:
 "_Promoted to [VK_EXT_debug_utils](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_debug_utils.html) extension_".

# Tested on
- Macbook M1 via MoltenVK with VulkanSDK version 1.3.290.0
- Windows 10, NVidia GTX 1660TI with VulkanSDK version 1.3.290.0 