### PR TITLE
Опция подавить создание барьеров при вызове createDescriptorSet

### DIFF
--- a/etna/include/etna/BarrierBehavoir.hpp
+++ b/etna/include/etna/BarrierBehavoir.hpp
@@ -12,4 +12,12 @@ enum class BarrierBehavoir
   eGenerateBarriers
 };
 
+/// Force set_state to create barriers, even when they seem unnecessary
+enum class ForceSetState
+{
+  // foo(true) is less readable than foo(ForceSetState::eTrue)
+  eFalse,
+  eTrue
+};
+
 #endif // BARRIERBEHAVOIR_HPP

--- a/etna/include/etna/BarrierBehavoir.hpp
+++ b/etna/include/etna/BarrierBehavoir.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#ifndef BARRIERBEHAVOIR_HPP
+#define BARRIERBEHAVOIR_HPP
+
+enum class BarrierBehavoir
+{
+  /// Inherits it's value from etna configuration
+  eDefault,
+
+  /// Explicit way to set behavoir. Ignores etna config
+  eSuppressBarriers,
+  eGenerateBarriers
+};
+
+#endif // BARRIERBEHAVOIR_HPP

--- a/etna/include/etna/DescriptorSet.hpp
+++ b/etna/include/etna/DescriptorSet.hpp
@@ -39,20 +39,29 @@ struct Binding
 /*Maybe we need a hierarchy of descriptor sets*/
 struct DescriptorSet
 {
+  enum class Behavoir
+  {
+    eDefault,
+    eNoProcessBarriers
+  };
   DescriptorSet() {}
   DescriptorSet(
     uint64_t gen,
     DescriptorLayoutId id,
     vk::DescriptorSet vk_set,
     std::vector<Binding> resources,
-    vk::CommandBuffer cmd_buffer)
+    vk::CommandBuffer cmd_buffer,
+    Behavoir behavoir = Behavoir::eDefault)
     : generation{gen}
     , layoutId{id}
     , set{vk_set}
     , bindings{std::move(resources)}
     , command_buffer{cmd_buffer}
   {
-    processBarriers();
+    if (behavoir != Behavoir::eNoProcessBarriers)
+    {
+      processBarriers();
+    }
   }
 
   bool isValid() const;
@@ -90,7 +99,10 @@ struct DynamicDescriptorPool
   void reset(uint32_t frames_in_flight);
 
   DescriptorSet allocateSet(
-    DescriptorLayoutId layout_id, std::vector<Binding> bindings, vk::CommandBuffer command_buffer);
+    DescriptorLayoutId layout_id,
+    std::vector<Binding> bindings,
+    vk::CommandBuffer command_buffer,
+    DescriptorSet::Behavoir behavoir = DescriptorSet::Behavoir::eDefault);
 
   bool isSetValid(const DescriptorSet& set) const
   {

--- a/etna/include/etna/DescriptorSet.hpp
+++ b/etna/include/etna/DescriptorSet.hpp
@@ -54,9 +54,7 @@ struct DescriptorSet
     , bindings{std::move(resources)}
     , command_buffer{cmd_buffer}
   {
-    if (
-      behavoir == BarrierBehavoir::eGenerateBarriers ||
-      (behavoir == BarrierBehavoir::eDefault && get_context().shouldGenerateBarriers()))
+    if (get_context().shouldGenerateBarriersWhen(behavoir))
     {
       processBarriers();
     }

--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -119,7 +119,8 @@ void set_state(
   vk::PipelineStageFlags2 pipeline_stage_flags,
   vk::AccessFlags2 access_flags,
   vk::ImageLayout layout,
-  vk::ImageAspectFlags aspect_flags);
+  vk::ImageAspectFlags aspect_flags,
+  ForceSetState force = ForceSetState::eFalse);
 
 /**
  * \brief Flushes all barriers resulting from set_state calls.

--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -10,7 +10,7 @@
 #include <etna/ShaderProgram.hpp>
 #include <etna/DescriptorSet.hpp>
 #include <etna/Image.hpp>
-
+#include <etna/BarrierBehavoir.hpp>
 
 namespace etna
 {
@@ -40,6 +40,9 @@ struct InitParams
 
   /// How much do we allow the CPU to "outrun" the GPU asynchronously
   uint32_t numFramesInFlight = 2;
+
+  /// Whether things like createDescriptorSet or renderTarget should auto-create barriers
+  bool generateBarriersAutomatically = true;
 };
 
 bool is_initilized();
@@ -94,7 +97,7 @@ DescriptorSet create_descriptor_set(
   DescriptorLayoutId layout,
   vk::CommandBuffer command_buffer,
   std::vector<Binding> bindings,
-  DescriptorSet::Behavoir behavoir = DescriptorSet::Behavoir::eDefault);
+  BarrierBehavoir behavoir = BarrierBehavoir::eDefault);
 
 Image create_image_from_bytes(
   Image::CreateInfo info, vk::CommandBuffer command_buffer, const void* data);

--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -91,7 +91,10 @@ ShaderProgramInfo get_shader_program(const char* name);
  * \return The descriptor set that can then be bound.
  */
 DescriptorSet create_descriptor_set(
-  DescriptorLayoutId layout, vk::CommandBuffer command_buffer, std::vector<Binding> bindings);
+  DescriptorLayoutId layout,
+  vk::CommandBuffer command_buffer,
+  std::vector<Binding> bindings,
+  DescriptorSet::Behavoir behavoir = DescriptorSet::Behavoir::eDefault);
 
 Image create_image_from_bytes(
   Image::CreateInfo info, vk::CommandBuffer command_buffer, const void* data);

--- a/etna/include/etna/GlobalContext.hpp
+++ b/etna/include/etna/GlobalContext.hpp
@@ -37,7 +37,7 @@ public:
   std::unique_ptr<Window> createWindow(Window::CreateInfo info);
   std::unique_ptr<PerFrameCmdMgr> createPerFrameCmdMgr();
   std::unique_ptr<OneShotCmdMgr> createOneShotCmdMgr();
-  bool shouldGenerateBarrierWhen(BarrierBehavoir behavoir) const;
+  bool shouldGenerateBarriersWhen(BarrierBehavoir behavoir) const;
 
   vk::Device getDevice() const { return vkDevice.get(); }
   vk::PhysicalDevice getPhysicalDevice() const { return vkPhysDevice; }

--- a/etna/include/etna/GlobalContext.hpp
+++ b/etna/include/etna/GlobalContext.hpp
@@ -9,6 +9,7 @@
 #include <etna/Image.hpp>
 #include <etna/Buffer.hpp>
 #include <etna/Window.hpp>
+#include <etna/BarrierBehavoir.hpp>
 
 #include <vk_mem_alloc.h>
 
@@ -36,13 +37,13 @@ public:
   std::unique_ptr<Window> createWindow(Window::CreateInfo info);
   std::unique_ptr<PerFrameCmdMgr> createPerFrameCmdMgr();
   std::unique_ptr<OneShotCmdMgr> createOneShotCmdMgr();
+  bool shouldGenerateBarrierWhen(BarrierBehavoir behavoir) const;
 
   vk::Device getDevice() const { return vkDevice.get(); }
   vk::PhysicalDevice getPhysicalDevice() const { return vkPhysDevice; }
   vk::Instance getInstance() const { return vkInstance.get(); }
   vk::Queue getQueue() const { return universalQueue; }
   uint32_t getQueueFamilyIdx() const { return universalQueueFamilyIdx; }
-  bool shouldGenerateBarriers() const { return shouldGenerateBarriersFlag; }
 
   ShaderProgramManager& getShaderManager();
   PipelineManager& getPipelineManager();

--- a/etna/include/etna/GlobalContext.hpp
+++ b/etna/include/etna/GlobalContext.hpp
@@ -42,6 +42,7 @@ public:
   vk::Instance getInstance() const { return vkInstance.get(); }
   vk::Queue getQueue() const { return universalQueue; }
   uint32_t getQueueFamilyIdx() const { return universalQueueFamilyIdx; }
+  bool shouldGenerateBarriers() const { return shouldGenerateBarriersFlag; }
 
   ShaderProgramManager& getShaderManager();
   PipelineManager& getPipelineManager();
@@ -82,6 +83,8 @@ private:
   std::unique_ptr<DynamicDescriptorPool> descriptorPool;
   std::unique_ptr<ResourceStates> resourceTracking;
   std::unique_ptr<void, void (*)(void*)> tracyCtx;
+
+  bool shouldGenerateBarriersFlag;
 };
 
 GlobalContext& get_context();

--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -6,7 +6,7 @@
 
 #include <etna/Vulkan.hpp>
 #include <etna/Image.hpp>
-
+#include <etna/BarrierBehavoir.hpp>
 
 namespace etna
 {
@@ -42,7 +42,8 @@ public:
     vk::Rect2D rect,
     const std::vector<AttachmentParams>& color_attachments,
     AttachmentParams depth_attachment,
-    AttachmentParams stencil_attachment);
+    AttachmentParams stencil_attachment,
+    BarrierBehavoir behavoir = BarrierBehavoir::eDefault);
 
   // We can't use the default argument for stencil_attachment due to gcc bug 88165
   // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165
@@ -50,8 +51,9 @@ public:
     vk::CommandBuffer cmd_buff,
     vk::Rect2D rect,
     const std::vector<AttachmentParams>& color_attachments,
-    AttachmentParams depth_attachment)
-    : RenderTargetState(cmd_buff, rect, color_attachments, depth_attachment, {}){};
+    AttachmentParams depth_attachment,
+    BarrierBehavoir behavoir = BarrierBehavoir::eDefault)
+    : RenderTargetState(cmd_buff, rect, color_attachments, depth_attachment, {}, behavoir){};
 
   ~RenderTargetState();
 };

--- a/etna/source/DescriptorSet.cpp
+++ b/etna/source/DescriptorSet.cpp
@@ -59,7 +59,7 @@ DescriptorSet DynamicDescriptorPool::allocateSet(
   DescriptorLayoutId layout_id,
   std::vector<Binding> bindings,
   vk::CommandBuffer command_buffer,
-  DescriptorSet::Behavoir behavoir)
+  BarrierBehavoir behavoir)
 {
   auto& dslCache = get_context().getDescriptorSetLayouts();
   auto setLayouts = {dslCache.getVkLayout(layout_id)};

--- a/etna/source/DescriptorSet.cpp
+++ b/etna/source/DescriptorSet.cpp
@@ -56,7 +56,10 @@ void DynamicDescriptorPool::destroyAllocatedSets()
 }
 
 DescriptorSet DynamicDescriptorPool::allocateSet(
-  DescriptorLayoutId layout_id, std::vector<Binding> bindings, vk::CommandBuffer command_buffer)
+  DescriptorLayoutId layout_id,
+  std::vector<Binding> bindings,
+  vk::CommandBuffer command_buffer,
+  DescriptorSet::Behavoir behavoir)
 {
   auto& dslCache = get_context().getDescriptorSetLayouts();
   auto setLayouts = {dslCache.getVkLayout(layout_id)};
@@ -68,7 +71,7 @@ DescriptorSet DynamicDescriptorPool::allocateSet(
   vk::DescriptorSet vkSet{};
   ETNA_VERIFY(vkDevice.allocateDescriptorSets(&info, &vkSet) == vk::Result::eSuccess);
   return DescriptorSet{
-    workCount.batchIndex(), layout_id, vkSet, std::move(bindings), command_buffer};
+    workCount.batchIndex(), layout_id, vkSet, std::move(bindings), command_buffer, behavoir};
 }
 
 static bool is_image_resource(vk::DescriptorType ds_type)

--- a/etna/source/Etna.cpp
+++ b/etna/source/Etna.cpp
@@ -71,7 +71,7 @@ DescriptorSet create_descriptor_set(
   DescriptorLayoutId layout,
   vk::CommandBuffer command_buffer,
   std::vector<Binding> bindings,
-  DescriptorSet::Behavoir behavoir)
+  BarrierBehavoir behavoir)
 {
   auto set = gContext->getDescriptorPool().allocateSet(layout, bindings, command_buffer, behavoir);
   write_set(set);

--- a/etna/source/Etna.cpp
+++ b/etna/source/Etna.cpp
@@ -68,9 +68,12 @@ ShaderProgramInfo get_shader_program(const char* name)
 }
 
 DescriptorSet create_descriptor_set(
-  DescriptorLayoutId layout, vk::CommandBuffer command_buffer, std::vector<Binding> bindings)
+  DescriptorLayoutId layout,
+  vk::CommandBuffer command_buffer,
+  std::vector<Binding> bindings,
+  DescriptorSet::Behavoir behavoir)
 {
-  auto set = gContext->getDescriptorPool().allocateSet(layout, bindings, command_buffer);
+  auto set = gContext->getDescriptorPool().allocateSet(layout, bindings, command_buffer, behavoir);
   write_set(set);
   return set;
 }

--- a/etna/source/Etna.cpp
+++ b/etna/source/Etna.cpp
@@ -158,10 +158,11 @@ void set_state(
   vk::PipelineStageFlags2 pipeline_stage_flags,
   vk::AccessFlags2 access_flags,
   vk::ImageLayout layout,
-  vk::ImageAspectFlags aspect_flags)
+  vk::ImageAspectFlags aspect_flags,
+  ForceSetState force)
 {
   etna::get_context().getResourceTracker().setTextureState(
-    com_buffer, image, pipeline_stage_flags, access_flags, layout, aspect_flags);
+    com_buffer, image, pipeline_stage_flags, access_flags, layout, aspect_flags, force);
 }
 
 void finish_frame(vk::CommandBuffer com_buffer)

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -491,4 +491,14 @@ ResourceStates& GlobalContext::getResourceTracker()
 
 GlobalContext::~GlobalContext() = default;
 
+
+bool GlobalContext::shouldGenerateBarrierWhen(BarrierBehavoir behavoir) const
+{
+  if (behavoir == BarrierBehavoir::eDefault)
+  {
+    return shouldGenerateBarriersFlag;
+  }
+  return behavoir == BarrierBehavoir::eGenerateBarriers;
+}
+
 } // namespace etna

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -492,7 +492,7 @@ ResourceStates& GlobalContext::getResourceTracker()
 GlobalContext::~GlobalContext() = default;
 
 
-bool GlobalContext::shouldGenerateBarrierWhen(BarrierBehavoir behavoir) const
+bool GlobalContext::shouldGenerateBarriersWhen(BarrierBehavoir behavoir) const
 {
   if (behavoir == BarrierBehavoir::eDefault)
   {

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -300,6 +300,7 @@ GlobalContext::GlobalContext(const InitParams& params)
                (void)ctx;
                TracyVkDestroy(reinterpret_cast<TracyVkCtx>(ctx));
              }}
+  , shouldGenerateBarriersFlag{params.generateBarriersAutomatically}
 {
   // Proper initialization of vulkan is tricky, as we need to
   // dynamically link vulkan-1.dll and load symbols for various

--- a/etna/source/RenderTargetStates.cpp
+++ b/etna/source/RenderTargetStates.cpp
@@ -14,7 +14,8 @@ RenderTargetState::RenderTargetState(
   vk::Rect2D rect,
   const std::vector<AttachmentParams>& color_attachments,
   AttachmentParams depth_attachment,
-  AttachmentParams stencil_attachment)
+  AttachmentParams stencil_attachment,
+  BarrierBehavoir behavoir)
 {
   ETNA_VERIFYF(!inScope, "RenderTargetState scopes shouldn't overlap.");
   inScope = true;
@@ -42,12 +43,15 @@ RenderTargetState::RenderTargetState(
     attachmentInfos[i].clearValue = color_attachments[i].clearColorValue;
 
     etna::get_context().getResourceTracker().setColorTarget(
-      commandBuffer, color_attachments[i].image);
+      commandBuffer, color_attachments[i].image, behavoir);
 
     if (color_attachments[i].resolveImage)
     {
       etna::get_context().getResourceTracker().setResolveTarget(
-        commandBuffer, color_attachments[i].resolveImage, vk::ImageAspectFlagBits::eColor);
+        commandBuffer,
+        color_attachments[i].resolveImage,
+        vk::ImageAspectFlagBits::eColor,
+        behavoir);
 
       attachmentInfos[i].resolveImageLayout = vk::ImageLayout::eGeneral;
       attachmentInfos[i].resolveImageView = color_attachments[i].resolveImageView;
@@ -85,14 +89,16 @@ RenderTargetState::RenderTargetState(
     etna::get_context().getResourceTracker().setDepthStencilTarget(
       commandBuffer,
       depth_attachment.image,
-      vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil);
+      vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil,
+      behavoir);
 
     if (depth_attachment.resolveImage && stencil_attachment.resolveImage)
     {
       etna::get_context().getResourceTracker().setResolveTarget(
         commandBuffer,
         depth_attachment.resolveImage,
-        vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil);
+        vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil,
+        behavoir);
     }
   }
   else
@@ -102,14 +108,16 @@ RenderTargetState::RenderTargetState(
       etna::get_context().getResourceTracker().setDepthStencilTarget(
         commandBuffer,
         depth_attachment.image,
-        depth_attachment.imageAspect.value_or(vk::ImageAspectFlagBits::eDepth));
+        depth_attachment.imageAspect.value_or(vk::ImageAspectFlagBits::eDepth),
+        behavoir);
 
       if (depth_attachment.resolveImage)
       {
         etna::get_context().getResourceTracker().setResolveTarget(
           commandBuffer,
           depth_attachment.resolveImage,
-          depth_attachment.resolveImageAspect.value_or(vk::ImageAspectFlagBits::eDepth));
+          depth_attachment.resolveImageAspect.value_or(vk::ImageAspectFlagBits::eDepth),
+          behavoir);
       }
     }
 
@@ -118,14 +126,16 @@ RenderTargetState::RenderTargetState(
       etna::get_context().getResourceTracker().setDepthStencilTarget(
         commandBuffer,
         stencil_attachment.image,
-        stencil_attachment.imageAspect.value_or(vk::ImageAspectFlagBits::eStencil));
+        stencil_attachment.imageAspect.value_or(vk::ImageAspectFlagBits::eStencil),
+        behavoir);
 
       if (stencil_attachment.resolveImage)
       {
         etna::get_context().getResourceTracker().setResolveTarget(
           commandBuffer,
           stencil_attachment.resolveImage,
-          stencil_attachment.resolveImageAspect.value_or(vk::ImageAspectFlagBits::eStencil));
+          stencil_attachment.resolveImageAspect.value_or(vk::ImageAspectFlagBits::eStencil),
+          behavoir);
       }
     }
   }

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -43,7 +43,7 @@ void ResourceStates::setTextureState(
     .owner = com_buffer,
   };
   auto& oldState = std::get<0>(currentStates[resHandle]);
-  if (force == ForceSetState::eTrue && newState == oldState)
+  if (force == ForceSetState::eFalse && newState == oldState)
     return;
   barriersToFlush.push_back(vk::ImageMemoryBarrier2{
     .srcStageMask = oldState.piplineStageFlags,

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -83,9 +83,7 @@ void ResourceStates::flushBarriers(vk::CommandBuffer com_buf)
 void ResourceStates::setColorTarget(
   vk::CommandBuffer com_buffer, vk::Image image, BarrierBehavoir behavoir)
 {
-  if (
-    behavoir == BarrierBehavoir::eGenerateBarriers ||
-    (behavoir == BarrierBehavoir::eDefault && get_context().shouldGenerateBarriers()))
+  if (get_context().shouldGenerateBarriersWhen(behavoir))
   {
     setTextureState(
       com_buffer,
@@ -103,9 +101,7 @@ void ResourceStates::setDepthStencilTarget(
   vk::ImageAspectFlags aspect_flags,
   BarrierBehavoir behavoir)
 {
-  if (
-    behavoir == BarrierBehavoir::eGenerateBarriers ||
-    (behavoir == BarrierBehavoir::eDefault && get_context().shouldGenerateBarriers()))
+  if (get_context().shouldGenerateBarriersWhen(behavoir))
   {
     setTextureState(
       com_buffer,
@@ -124,9 +120,7 @@ void ResourceStates::setResolveTarget(
   vk::ImageAspectFlags aspect_flags,
   BarrierBehavoir behavoir)
 {
-  if (
-    behavoir == BarrierBehavoir::eGenerateBarriers ||
-    (behavoir == BarrierBehavoir::eDefault && get_context().shouldGenerateBarriers()))
+  if (get_context().shouldGenerateBarriersWhen(behavoir))
   {
     setTextureState(
       com_buffer,

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -1,4 +1,5 @@
 #include "StateTracking.hpp"
+#include "etna/GlobalContext.hpp"
 
 #include <bit>
 
@@ -78,40 +79,62 @@ void ResourceStates::flushBarriers(vk::CommandBuffer com_buf)
   barriersToFlush.clear();
 }
 
-void ResourceStates::setColorTarget(vk::CommandBuffer com_buffer, vk::Image image)
+void ResourceStates::setColorTarget(
+  vk::CommandBuffer com_buffer, vk::Image image, BarrierBehavoir behavoir)
 {
-  setTextureState(
-    com_buffer,
-    image,
-    vk::PipelineStageFlagBits2::eColorAttachmentOutput,
-    vk::AccessFlagBits2::eColorAttachmentWrite,
-    vk::ImageLayout::eColorAttachmentOptimal,
-    vk::ImageAspectFlagBits::eColor);
+  if (
+    behavoir == BarrierBehavoir::eGenerateBarriers ||
+    (behavoir == BarrierBehavoir::eDefault && get_context().shouldGenerateBarriers()))
+  {
+    setTextureState(
+      com_buffer,
+      image,
+      vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+      vk::AccessFlagBits2::eColorAttachmentWrite,
+      vk::ImageLayout::eColorAttachmentOptimal,
+      vk::ImageAspectFlagBits::eColor);
+  }
 }
 
 void ResourceStates::setDepthStencilTarget(
-  vk::CommandBuffer com_buffer, vk::Image image, vk::ImageAspectFlags aspect_flags)
+  vk::CommandBuffer com_buffer,
+  vk::Image image,
+  vk::ImageAspectFlags aspect_flags,
+  BarrierBehavoir behavoir)
 {
-  setTextureState(
-    com_buffer,
-    image,
-    vk::PipelineStageFlagBits2::eEarlyFragmentTests |
-      vk::PipelineStageFlagBits2::eLateFragmentTests,
-    vk::AccessFlagBits2::eDepthStencilAttachmentWrite,
-    vk::ImageLayout::eDepthStencilAttachmentOptimal,
-    aspect_flags);
+  if (
+    behavoir == BarrierBehavoir::eGenerateBarriers ||
+    (behavoir == BarrierBehavoir::eDefault && get_context().shouldGenerateBarriers()))
+  {
+    setTextureState(
+      com_buffer,
+      image,
+      vk::PipelineStageFlagBits2::eEarlyFragmentTests |
+        vk::PipelineStageFlagBits2::eLateFragmentTests,
+      vk::AccessFlagBits2::eDepthStencilAttachmentWrite,
+      vk::ImageLayout::eDepthStencilAttachmentOptimal,
+      aspect_flags);
+  }
 }
 
 void ResourceStates::setResolveTarget(
-  vk::CommandBuffer com_buffer, vk::Image image, vk::ImageAspectFlags aspect_flags)
+  vk::CommandBuffer com_buffer,
+  vk::Image image,
+  vk::ImageAspectFlags aspect_flags,
+  BarrierBehavoir behavoir)
 {
-  setTextureState(
-    com_buffer,
-    image,
-    vk::PipelineStageFlagBits2::eResolve,
-    vk::AccessFlagBits2::eTransferWrite,
-    vk::ImageLayout::eGeneral,
-    aspect_flags);
+  if (
+    behavoir == BarrierBehavoir::eGenerateBarriers ||
+    (behavoir == BarrierBehavoir::eDefault && get_context().shouldGenerateBarriers()))
+  {
+    setTextureState(
+      com_buffer,
+      image,
+      vk::PipelineStageFlagBits2::eResolve,
+      vk::AccessFlagBits2::eTransferWrite,
+      vk::ImageLayout::eGeneral,
+      aspect_flags);
+  }
 }
 
 } // namespace etna

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -28,7 +28,8 @@ void ResourceStates::setTextureState(
   vk::PipelineStageFlags2 pipeline_stage_flag,
   vk::AccessFlags2 access_flags,
   vk::ImageLayout layout,
-  vk::ImageAspectFlags aspect_flags)
+  vk::ImageAspectFlags aspect_flags,
+  ForceSetState force)
 {
   HandleType resHandle = std::bit_cast<HandleType>(static_cast<VkImage>(image));
   if (currentStates.count(resHandle) == 0)
@@ -42,7 +43,7 @@ void ResourceStates::setTextureState(
     .owner = com_buffer,
   };
   auto& oldState = std::get<0>(currentStates[resHandle]);
-  if (newState == oldState)
+  if (force == ForceSetState::eTrue && newState == oldState)
     return;
   barriersToFlush.push_back(vk::ImageMemoryBarrier2{
     .srcStageMask = oldState.piplineStageFlags,

--- a/etna/source/StateTracking.hpp
+++ b/etna/source/StateTracking.hpp
@@ -39,7 +39,8 @@ public:
     vk::PipelineStageFlags2 pipeline_stage_flag,
     vk::AccessFlags2 access_flags,
     vk::ImageLayout layout,
-    vk::ImageAspectFlags aspect_flags);
+    vk::ImageAspectFlags aspect_flags,
+    ForceSetState force = ForceSetState::eFalse);
 
   void setColorTarget(
     vk::CommandBuffer com_buffer,

--- a/etna/source/StateTracking.hpp
+++ b/etna/source/StateTracking.hpp
@@ -3,6 +3,7 @@
 #define ETNA_STATETRACKING_HPP_INCLUDED
 
 #include "etna/Vulkan.hpp"
+#include "etna/BarrierBehavoir.hpp"
 
 #include <variant>
 #include <unordered_map>
@@ -40,11 +41,20 @@ public:
     vk::ImageLayout layout,
     vk::ImageAspectFlags aspect_flags);
 
-  void setColorTarget(vk::CommandBuffer com_buffer, vk::Image image);
+  void setColorTarget(
+    vk::CommandBuffer com_buffer,
+    vk::Image image,
+    BarrierBehavoir behavoir = BarrierBehavoir::eDefault);
   void setDepthStencilTarget(
-    vk::CommandBuffer com_buffer, vk::Image image, vk::ImageAspectFlags aspect_flags);
+    vk::CommandBuffer com_buffer,
+    vk::Image image,
+    vk::ImageAspectFlags aspect_flags,
+    BarrierBehavoir behavoir = BarrierBehavoir::eDefault);
   void setResolveTarget(
-    vk::CommandBuffer com_buffer, vk::Image image, vk::ImageAspectFlags aspect_flags);
+    vk::CommandBuffer com_buffer,
+    vk::Image image,
+    vk::ImageAspectFlags aspect_flags,
+    BarrierBehavoir behavoir = BarrierBehavoir::eDefault);
 
   void flushBarriers(vk::CommandBuffer com_buf);
 };


### PR DESCRIPTION
Добавил опцию подавить создание барьеров при вызове createDescriptorSet. Дефолтное поведение createDescriptorSet создаёт кучу проблем, которые нетривиально разрешить, а автоматическая генерация барьеров зачастую создаёт лишние зависимости