### PR TITLE
minor refactoring

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,7 @@ jobs:
         check-path: 'etna'
         fallback-style: 'none'
 
-    - uses: ZedThree/clang-tidy-review@v0.14.0 # v0.17 is buggy
+    - uses: ZedThree/clang-tidy-review@v0.20.1
       id: review
       with:
         apt_packages: 'wget,libx11-dev'
@@ -31,8 +31,8 @@ jobs:
         cmake_command: | # Awful, dirty hacks to get the vulkan-sdk version we need
           wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | \
             tee /etc/apt/trusted.gpg.d/lunarg.asc && \
-          wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.275-jammy.list \
-            https://packages.lunarg.com/vulkan/1.3.275/lunarg-vulkan-1.3.275-jammy.list && \
+          wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.296-noble.list \
+            https://packages.lunarg.com/vulkan/1.3.296/lunarg-vulkan-1.3.296-noble.list && \
           apt update && \
           apt-get -y install libvulkan-dev vulkan-headers && \
           cmake -Bbuild -S. -DCMAKE_EXPORT_COMPILE_COMMANDS=on
@@ -41,4 +41,4 @@ jobs:
 
     # Upload review results as artifacts, a different workflow posts them
     # as comments. This is required due to security stuff.
-    - uses: ZedThree/clang-tidy-review/upload@v0.14.0 # v0.17 is buggy
+    - uses: ZedThree/clang-tidy-review/upload@v0.20.1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .cache
 build
 out
+etna/include/etna/EtnaEngineConfig.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option(TRACY_ENABLE "Enable profiling" ${ETNA_DEBUG})
 
 include("get_cpm.cmake")
 include("thirdparty.cmake")
-
+include("get_version.cmake")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(TRACY_ENABLE "Enable profiling" ${ETNA_DEBUG})
 include("get_cpm.cmake")
 include("thirdparty.cmake")
 include("get_version.cmake")
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 

--- a/etna/CMakeLists.txt
+++ b/etna/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
+set(ETNA_ENGINE_CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/include/etna/EtnaEngineConfig.hpp)
+configure_file(${ETNA_ENGINE_CONFIG_FILE}.in ${ETNA_ENGINE_CONFIG_FILE} @ONLY)
 
 add_library(etna
   "source/Image.cpp"

--- a/etna/include/etna/Buffer.hpp
+++ b/etna/include/etna/Buffer.hpp
@@ -48,7 +48,7 @@ public:
   [[nodiscard]] vk::Buffer get() const { return buffer; }
   [[nodiscard]] std::byte* data() { return mapped; }
 
-  BufferBinding genBinding(vk::DeviceSize offset = 0, vk::DeviceSize range = VK_WHOLE_SIZE) const;
+  BufferBinding genBinding(vk::DeviceSize offset = 0, vk::DeviceSize range = vk::WholeSize) const;
 
   // If the buffer is in CPU_TO_GPU or GPU_TO_CPU memory, returns a CPU-accessible
   // pointer to the start of this buffer's bytes, which can be used for reading or

--- a/etna/include/etna/DescriptorSetLayout.hpp
+++ b/etna/include/etna/DescriptorSetLayout.hpp
@@ -65,7 +65,8 @@ struct DescriptorSetLayoutCache
 {
   DescriptorSetLayoutCache() {}
   ~DescriptorSetLayoutCache()
-  { /*make device global and call clear hear*/
+  {
+    // make device global and call clear hear
   }
 
   DescriptorLayoutId registerLayout(vk::Device device, const DescriptorSetInfo& info);

--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -26,7 +26,7 @@ struct InitParams
   /// Can be anything
   const char* applicationName;
 
-  /// Use VK_MAKE_VERSION macro
+  /// Use vk::makeApiVersion macro
   uint32_t applicationVersion;
 
   std::span<char const* const> instanceExtensions{};

--- a/etna/include/etna/EtnaConfig.hpp
+++ b/etna/include/etna/EtnaConfig.hpp
@@ -22,9 +22,6 @@ inline constexpr std::array VULKAN_LAYERS = {
 
 inline constexpr uint32_t VULKAN_API_VERSION = vk::ApiVersion13;
 
-inline constexpr const char* ETNA_ENGINE_NAME = "etna";
-inline constexpr uint32_t ETNA_VERSION = vk::makeApiVersion(0, ETNA_MAJOR, ETNA_MINOR, ETNA_PATCH);
-
 inline constexpr size_t MAX_FRAMES_INFLIGHT = 4;
 
 } // namespace etna

--- a/etna/include/etna/EtnaConfig.hpp
+++ b/etna/include/etna/EtnaConfig.hpp
@@ -23,7 +23,7 @@ inline constexpr std::array VULKAN_LAYERS = {
 inline constexpr uint32_t VULKAN_API_VERSION = vk::ApiVersion13;
 
 inline constexpr const char* ETNA_ENGINE_NAME = "etna";
-inline constexpr uint32_t ETNA_VERSION = vk::makeApiVersion(0, 0, 1, 0);
+inline constexpr uint32_t ETNA_VERSION = vk::makeApiVersion(0, ETNA_MAJOR, ETNA_MINOR, ETNA_PATCH);
 
 inline constexpr size_t MAX_FRAMES_INFLIGHT = 4;
 

--- a/etna/include/etna/EtnaConfig.hpp
+++ b/etna/include/etna/EtnaConfig.hpp
@@ -20,10 +20,10 @@ inline constexpr std::array VULKAN_LAYERS = {
 };
 #endif
 
-inline constexpr uint32_t VULKAN_API_VERSION = VK_API_VERSION_1_3;
+inline constexpr uint32_t VULKAN_API_VERSION = vk::ApiVersion13;
 
 inline constexpr const char* ETNA_ENGINE_NAME = "etna";
-inline constexpr uint32_t ETNA_VERSION = VK_MAKE_VERSION(0, 1, 0);
+inline constexpr uint32_t ETNA_VERSION = vk::makeApiVersion(0, 0, 1, 0);
 
 inline constexpr size_t MAX_FRAMES_INFLIGHT = 4;
 

--- a/etna/include/etna/EtnaEngineConfig.hpp.in
+++ b/etna/include/etna/EtnaEngineConfig.hpp.in
@@ -1,0 +1,17 @@
+#pragma once
+#ifndef ETNA_ETNA_ENGINE_CONFIG_HPP_INCLUDED
+#define ETNA_ETNA_ENGINE_CONFIG_HPP_INCLUDED
+
+#include <etna/Vulkan.hpp>
+
+
+namespace etna
+{
+
+inline constexpr const char* ETNA_ENGINE_NAME = "etna";
+
+inline constexpr uint32_t ETNA_ENGINE_VERSION = vk::makeApiVersion(0, @ETNA_GIT_VERSION@);
+
+} // namespace etna
+
+#endif // ETNA_ETNA_CONFIG_HPP_INCLUDED

--- a/etna/include/etna/Image.hpp
+++ b/etna/include/etna/Image.hpp
@@ -113,7 +113,7 @@ public:
   ImageBinding genBinding(
     vk::Sampler sampler,
     vk::ImageLayout layout,
-    ViewParams params = {0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS, {}, {}}) const;
+    ViewParams params = {0, vk::RemainingMipLevels, 0, vk::RemainingArrayLayers, {}, {}}) const;
 
   // Returns the "all" aspects combination of flags based on the image's real format
   vk::ImageAspectFlags getAspectMaskByFormat() const;

--- a/etna/include/etna/RenderTargetStates.hpp
+++ b/etna/include/etna/RenderTargetStates.hpp
@@ -19,8 +19,8 @@ class RenderTargetState
 public:
   struct AttachmentParams
   {
-    vk::Image image = VK_NULL_HANDLE;
-    vk::ImageView view = VK_NULL_HANDLE;
+    vk::Image image = {};
+    vk::ImageView view = {};
     std::optional<vk::ImageAspectFlags> imageAspect{};
     vk::AttachmentLoadOp loadOp = vk::AttachmentLoadOp::eClear;
     vk::AttachmentStoreOp storeOp = vk::AttachmentStoreOp::eStore;
@@ -31,8 +31,8 @@ public:
     // but not produce a final single-sample result.
     // These fields below are for the final MSAA image.
     // Ignore unless you know what MSAA is and aren't sure you need it.
-    vk::Image resolveImage = VK_NULL_HANDLE;
-    vk::ImageView resolveImageView = VK_NULL_HANDLE;
+    vk::Image resolveImage = {};
+    vk::ImageView resolveImageView = {};
     std::optional<vk::ImageAspectFlags> resolveImageAspect{};
     vk::ResolveModeFlagBits resolveMode = vk::ResolveModeFlagBits::eNone;
   };
@@ -53,7 +53,9 @@ public:
     const std::vector<AttachmentParams>& color_attachments,
     AttachmentParams depth_attachment,
     BarrierBehavoir behavoir = BarrierBehavoir::eDefault)
-    : RenderTargetState(cmd_buff, rect, color_attachments, depth_attachment, {}, behavoir){};
+    : RenderTargetState(cmd_buff, rect, color_attachments, depth_attachment, {}, behavoir)
+  {
+  }
 
   ~RenderTargetState();
 };

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -11,6 +11,7 @@
 #include <etna/DescriptorSet.hpp>
 #include <etna/Assert.hpp>
 #include <etna/EtnaConfig.hpp>
+#include <etna/EtnaEngineConfig.hpp>
 #include <etna/Window.hpp>
 #include <etna/PerFrameCmdMgr.hpp>
 #include <etna/OneShotCmdMgr.hpp>
@@ -27,7 +28,7 @@ static vk::UniqueInstance createInstance(const InitParams& params)
     .pApplicationName = params.applicationName,
     .applicationVersion = params.applicationVersion,
     .pEngineName = ETNA_ENGINE_NAME,
-    .engineVersion = ETNA_VERSION,
+    .engineVersion = ETNA_ENGINE_VERSION,
     .apiVersion = VULKAN_API_VERSION,
   };
 

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -33,12 +33,12 @@ static vk::UniqueInstance createInstance(const InitParams& params)
 
   std::vector<const char*> extensions(
     params.instanceExtensions.begin(), params.instanceExtensions.end());
-  extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+  extensions.push_back(vk::EXTDebugUtilsExtensionName);
 
   // NOTE: Extension for the vulkan loader to list non-conformant implementations, such as
   // for example MoltenVK on Apple devices.
 #if defined(__APPLE__)
-  extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+  extensions.push_back(vk::KHRPortabilityEnumerationExtensionName);
 #endif
 
   std::vector<const char*> layers(VULKAN_LAYERS.begin(), VULKAN_LAYERS.end());
@@ -100,7 +100,7 @@ static OptionalExtensionsFound collect_optional_extensions_to_use(vk::PhysicalDe
   {
     if (
       safe_view_of_array(ext.extensionName) ==
-      std::string_view(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME))
+      std::string_view(vk::KHRCalibratedTimestampsExtensionName))
       result.hasVkExtCalibratedTimestamps = true;
   }
 
@@ -221,31 +221,31 @@ static vk::UniqueDevice create_logical_device(
   vk::PhysicalDeviceDynamicRenderingFeatures dynamicRenderingFeature{
     // Evil const cast due to C not having const
     .pNext = const_cast<vk::PhysicalDeviceFeatures2*>(&params.features), // NOLINT
-    .dynamicRendering = VK_TRUE,
+    .dynamicRendering = vk::True,
   };
 
   vk::PhysicalDeviceSynchronization2Features sync2Feature{
     .pNext = &dynamicRenderingFeature,
-    .synchronization2 = VK_TRUE,
+    .synchronization2 = vk::True,
   };
 
   std::vector<char const*> deviceExtensions(
     params.deviceExtensions.begin(), params.deviceExtensions.end());
 
   if (optional_exts.hasVkExtCalibratedTimestamps)
-    deviceExtensions.push_back(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME);
+  {
+    deviceExtensions.push_back(vk::KHRCalibratedTimestampsExtensionName);
+  }
 
-    // NOTE: These extensions are needed on MoltenVK to be set explicitly due to
-    // it not fully supporting Vulkan 1.3 yet.
+  // NOTE: These extensions are needed on MoltenVK to be set explicitly due to
+  // it not fully supporting Vulkan 1.3 yet.
 #if defined(__APPLE__)
-  deviceExtensions.push_back(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-  deviceExtensions.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-  deviceExtensions.push_back(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
-#endif
+  deviceExtensions.push_back(vk::KHRDynamicRenderingExtensionName);
+  deviceExtensions.push_back(vk::KHRSynchronization2ExtensionName);
+  deviceExtensions.push_back(vk::KHRCopyCommands2ExtensionName);
 
   // NOTE: Enable non-conformant Vulkan implementations.
-#if defined(__APPLE__)
-  deviceExtensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+  deviceExtensions.push_back(vk::KHRPortabilitySubsetExtensionName);
 #endif
 
   // NOTE: original design of PhysicalDeviceFeatures did not

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -52,16 +52,16 @@ void ResourceStates::setTextureState(
     .dstAccessMask = newState.accessFlags,
     .oldLayout = oldState.layout,
     .newLayout = newState.layout,
-    .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-    .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+    .srcQueueFamilyIndex = vk::QueueFamilyIgnored,
+    .dstQueueFamilyIndex = vk::QueueFamilyIgnored,
     .image = image,
     .subresourceRange =
       {
         .aspectMask = aspect_flags,
         .baseMipLevel = 0,
-        .levelCount = VK_REMAINING_MIP_LEVELS,
+        .levelCount = vk::RemainingMipLevels,
         .baseArrayLayer = 0,
-        .layerCount = VK_REMAINING_ARRAY_LAYERS,
+        .layerCount = vk::RemainingArrayLayers,
       },
   });
   oldState = newState;

--- a/get_version.cmake
+++ b/get_version.cmake
@@ -1,0 +1,32 @@
+find_package(Git)
+
+if(GIT_EXECUTABLE)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE ETNA_VERSION
+    RESULT_VARIABLE ERROR_CODE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if (${ETNA_VERSION})
+    string(REGEX MATCHALL "[0-9]+" NUM_LIST ${ETNA_VERSION}) 
+    list(LENGTH NUM_LIST LEN)
+
+    if (LEN STREQUAL "3")
+      list(GET NUM_LIST 0 TMP)
+      add_definitions(-DETNA_MAJOR=${TMP})
+      list(GET NUM_LIST 1 TMP)
+      add_definitions(-DETNA_MINOR=${TMP})
+      list(GET NUM_LIST 2 TMP)
+      add_definitions(-DETNA_PATCH=${TMP})
+      return()
+    endif()
+  endif()
+endif()
+
+add_definitions(-DETNA_MAJOR=0)
+add_definitions(-DETNA_MINOR=1)
+add_definitions(-DETNA_PATCH=0)
+
+message("Failed to determine version from Git tags. Using default version 0.1.0")

--- a/get_version.cmake
+++ b/get_version.cmake
@@ -3,30 +3,18 @@ find_package(Git)
 if(GIT_EXECUTABLE)
   execute_process(
     COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE ETNA_VERSION
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_TAG
     RESULT_VARIABLE ERROR_CODE
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
-  if (${ETNA_VERSION})
-    string(REGEX MATCHALL "[0-9]+" NUM_LIST ${ETNA_VERSION}) 
-    list(LENGTH NUM_LIST LEN)
-
-    if (LEN STREQUAL "3")
-      list(GET NUM_LIST 0 TMP)
-      add_definitions(-DETNA_MAJOR=${TMP})
-      list(GET NUM_LIST 1 TMP)
-      add_definitions(-DETNA_MINOR=${TMP})
-      list(GET NUM_LIST 2 TMP)
-      add_definitions(-DETNA_PATCH=${TMP})
-      return()
-    endif()
+  set(VERSION_REGEX "^v([0-9]+)\.([0-9]+)\.([0-9]+)$")
+  if (${GIT_TAG} MATCHES ${VERSION_REGEX})
+    string(REGEX REPLACE ${VERSION_REGEX} "\\1, \\2, \\3" ETNA_GIT_VERSION "${GIT_TAG}")
+    return()
   endif()
 endif()
 
-add_definitions(-DETNA_MAJOR=0)
-add_definitions(-DETNA_MINOR=1)
-add_definitions(-DETNA_PATCH=0)
-
+set(ETNA_GIT_VERSION "0, 1, 0")
 message("Failed to determine version from Git tags. Using default version 0.1.0")


### PR DESCRIPTION
Changes:
- use cpp wrapper for (almost) all constants

  Also deprecated VK_EXT_calibrated_timestamps was
  replaced by VK_KHR_calibrated_timestamps.
  See https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_calibrated_timestamps.html#_promotion_to_vk_khr_calibrated_timestamps
  
  And deprecated VK_MAKE_VERSION was replaced by vk::makeApiVersion
  (thanks to Khronos for this very important change)

- add versioning based on git tags

- lint update: bump vulkan sdk to 1.3.296 and ubuntu to 24.04