### PR TITLE
Added PersistentDescriptorPool and PersitsendDescriptorSet to support bindless

### DIFF
--- a/etna/include/etna/BindingItems.hpp
+++ b/etna/include/etna/BindingItems.hpp
@@ -23,6 +23,11 @@ struct ImageBinding
   vk::DescriptorImageInfo descriptor_info;
 };
 
+struct SamplerBinding
+{
+  vk::DescriptorImageInfo descriptor_info;
+};
+
 } // namespace etna
 
 #endif // ETNA_BINDING_ITEMS_HPP_INCLUDED

--- a/etna/include/etna/DescriptorSet.hpp
+++ b/etna/include/etna/DescriptorSet.hpp
@@ -31,10 +31,16 @@ struct Binding
     , resources{buffer_info}
   {
   }
+  Binding(uint32_t rbinding, const SamplerBinding& sampler_info, uint32_t array_index = 0)
+    : binding{rbinding}
+    , arrayElem{array_index}
+    , resources{sampler_info}
+  {
+  }
 
   uint32_t binding;
   uint32_t arrayElem;
-  std::variant<ImageBinding, BufferBinding> resources;
+  std::variant<ImageBinding, BufferBinding, SamplerBinding> resources;
 };
 
 /*Maybe we need a hierarchy of descriptor sets*/
@@ -80,6 +86,33 @@ private:
   vk::CommandBuffer command_buffer;
 };
 
+struct PersistentDescriptorSet
+{
+  PersistentDescriptorSet() = default;
+  PersistentDescriptorSet(
+    DescriptorLayoutId id, vk::DescriptorSet vk_set, std::vector<Binding> resources)
+    : layoutId{id}
+    , set{vk_set}
+    , bindings{std::move(resources)}
+  {
+  }
+
+  bool isValid() const { return set != vk::DescriptorSet{}; }
+
+  vk::DescriptorSet getVkSet() const { return set; }
+
+  DescriptorLayoutId getLayoutId() const { return layoutId; }
+
+  const std::vector<Binding>& getBindings() const { return bindings; }
+
+  void processBarriers(vk::CommandBuffer cmd_buffer) const;
+
+private:
+  DescriptorLayoutId layoutId{};
+  vk::DescriptorSet set{};
+  std::vector<Binding> bindings{};
+};
+
 /**
  * Base version. Allocate and use descriptor sets while writing command buffer, they will be
  * destroyed automaticaly. Resource allocation tracking shoud be added. For long-living descriptor
@@ -113,7 +146,24 @@ private:
   GpuSharedResource<vk::UniqueDescriptorPool> pools;
 };
 
-void write_set(const DescriptorSet& dst);
+/**
+ * Base version. Allocate persistent descriptor sets from here, which will
+ * never be destroyed until program terminates. As stated above, this could
+ * be replaced with resource tracking.
+ */
+struct PersistentDescriptorPool
+{
+  explicit PersistentDescriptorPool(vk::Device dev);
+
+  PersistentDescriptorSet allocateSet(DescriptorLayoutId layout_id, std::vector<Binding> bindings);
+
+private:
+  vk::Device vkDevice;
+  vk::UniqueDescriptorPool pool;
+};
+
+template <class TDescriptorSet>
+void write_set(const TDescriptorSet& dst, bool allow_unbound_slots = false);
 
 } // namespace etna
 

--- a/etna/include/etna/Etna.hpp
+++ b/etna/include/etna/Etna.hpp
@@ -99,6 +99,25 @@ DescriptorSet create_descriptor_set(
   std::vector<Binding> bindings,
   BarrierBehavoir behavoir = BarrierBehavoir::eDefault);
 
+/**
+ * \brief Creates a persistent descriptor set which does not automatically set
+ * barriers and is not deallocated across frames. Otherwise similar to
+ * etna::create_descriptor_set.
+ * \note In order to generate barriers call processBarriers on the dset object
+ * passing the command buffer to it. The comment about etna::flush_barriers
+ * (see above) is also applicable here.
+ *
+ * \param layout The layout describing what bindings the target shader has.
+ * Use etna::get_shader_program to get it from the shader automatically.
+ * \param bindings The table of what to bind where.
+ * \param allow_unbound_slots Whether to not validate that the bindings cover
+ * all slots in the layout. Useful if bindless is not fully supported on your
+ * hw and you need to over-declare registers in the shader.
+ * \return The descriptor set that can then be bound.
+ */
+PersistentDescriptorSet create_persistent_descriptor_set(
+  DescriptorLayoutId layout, std::vector<Binding> bindings, bool allow_unbound_slots = false);
+
 Image create_image_from_bytes(
   Image::CreateInfo info, vk::CommandBuffer command_buffer, const void* data);
 

--- a/etna/include/etna/GlobalContext.hpp
+++ b/etna/include/etna/GlobalContext.hpp
@@ -21,6 +21,7 @@ struct DescriptorSetLayoutCache;
 struct ShaderProgramManager;
 class PipelineManager;
 struct DynamicDescriptorPool;
+struct PersistentDescriptorPool;
 class ResourceStates;
 class PerFrameCmdMgr;
 class OneShotCmdMgr;
@@ -49,6 +50,7 @@ public:
   PipelineManager& getPipelineManager();
   DescriptorSetLayoutCache& getDescriptorSetLayouts();
   DynamicDescriptorPool& getDescriptorPool();
+  PersistentDescriptorPool& getPersistentDescriptorPool();
   ResourceStates& getResourceTracker();
   GpuWorkCount& getMainWorkCount() { return mainWorkStream; }
   const GpuWorkCount& getMainWorkCount() const { return mainWorkStream; }
@@ -81,7 +83,8 @@ private:
   std::unique_ptr<DescriptorSetLayoutCache> descriptorSetLayouts;
   std::unique_ptr<ShaderProgramManager> shaderPrograms;
   std::unique_ptr<PipelineManager> pipelineManager;
-  std::unique_ptr<DynamicDescriptorPool> descriptorPool;
+  std::unique_ptr<DynamicDescriptorPool> perFrameDescriptorPool;
+  std::unique_ptr<PersistentDescriptorPool> persistentDescriptorPool;
   std::unique_ptr<ResourceStates> resourceTracking;
   std::unique_ptr<void, void (*)(void*)> tracyCtx;
 

--- a/etna/include/etna/Sampler.hpp
+++ b/etna/include/etna/Sampler.hpp
@@ -26,6 +26,9 @@ public:
 
   [[nodiscard]] vk::Sampler get() const { return sampler.get(); }
 
+  // Creates a binding to be used with etna::Binding and etna::create_descriptor_set
+  SamplerBinding genBinding() const;
+
 private:
   vk::UniqueSampler sampler{};
 };

--- a/etna/source/Etna.cpp
+++ b/etna/source/Etna.cpp
@@ -79,6 +79,14 @@ DescriptorSet create_descriptor_set(
   return set;
 }
 
+PersistentDescriptorSet create_persistent_descriptor_set(
+  DescriptorLayoutId layout, std::vector<Binding> bindings, bool allow_unbound_slots)
+{
+  auto set = gContext->getPersistentDescriptorPool().allocateSet(layout, bindings);
+  write_set(set, allow_unbound_slots);
+  return set;
+}
+
 Image create_image_from_bytes(Image::CreateInfo info, vk::CommandBuffer cmd_buf, const void* data)
 {
   const auto blockSize = vk::blockSize(info.format);

--- a/etna/source/GlobalContext.cpp
+++ b/etna/source/GlobalContext.cpp
@@ -380,7 +380,8 @@ GlobalContext::GlobalContext(const InitParams& params)
   descriptorSetLayouts = std::make_unique<DescriptorSetLayoutCache>();
   shaderPrograms = std::make_unique<ShaderProgramManager>();
   pipelineManager = std::make_unique<PipelineManager>(vkDevice.get(), *shaderPrograms);
-  descriptorPool = std::make_unique<DynamicDescriptorPool>(vkDevice.get(), mainWorkStream);
+  perFrameDescriptorPool = std::make_unique<DynamicDescriptorPool>(vkDevice.get(), mainWorkStream);
+  persistentDescriptorPool = std::make_unique<PersistentDescriptorPool>(vkDevice.get());
   resourceTracking = std::make_unique<ResourceStates>();
 
   auto tempPool =
@@ -482,7 +483,12 @@ DescriptorSetLayoutCache& GlobalContext::getDescriptorSetLayouts()
 
 DynamicDescriptorPool& GlobalContext::getDescriptorPool()
 {
-  return *descriptorPool;
+  return *perFrameDescriptorPool;
+}
+
+PersistentDescriptorPool& GlobalContext::getPersistentDescriptorPool()
+{
+  return *persistentDescriptorPool;
 }
 
 ResourceStates& GlobalContext::getResourceTracker()

--- a/etna/source/Sampler.cpp
+++ b/etna/source/Sampler.cpp
@@ -25,4 +25,9 @@ Sampler::Sampler(CreateInfo info)
   etna::set_debug_name(sampler.get(), info.name.data());
 }
 
+SamplerBinding Sampler::genBinding() const
+{
+  return SamplerBinding{vk::DescriptorImageInfo{sampler.get()}};
+}
+
 } // namespace etna


### PR DESCRIPTION
… bindless

1) Added PersitsendDescriptorSet class. It is a lighter version of
   DescriptorSet without generation data, command buffer refererence or
   automatic set_states. This is suited for dsets created once and alive
   for the duration of the program, i.e. bindless.
2) Added PersistentDescriptorPool to allocate such sets -- this pool is
   not multiplexed for frames in flight and never deallocates -- the
   only way to free dsets allocated from it is nuking the whole pool
   (and it lives in the context, so it's lifetime is the whole program).
3) Added create_persistent_descriptor_set free function to create such
   sets from the pool in the context.

This allowed me to implement bindless without pulling etna's guts out into my code.