### PR TITLE
Proper bindless support + cmake fix

### DIFF
--- a/etna/include/etna/DescriptorSet.hpp
+++ b/etna/include/etna/DescriptorSet.hpp
@@ -165,6 +165,8 @@ private:
 template <class TDescriptorSet>
 void write_set(const TDescriptorSet& dst, bool allow_unbound_slots = false);
 
+uint32_t get_num_descriptors_in_pool_for_type(vk::DescriptorType type);
+
 } // namespace etna
 
 #endif // ETNA_DESCRIPTOR_SET_HPP_INCLUDED

--- a/thirdparty.cmake
+++ b/thirdparty.cmake
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.25)
 
 
-find_package(Vulkan 1.3.275...<1.4.0 REQUIRED)
+find_package(Vulkan 1.3.275 REQUIRED)
+if(Vulkan_VERSION VERSION_GREATER_EQUAL 1.4.0)
+  message(FATAL_ERROR "Vulkan sdk version >1.3.xxx not supported")
+endif()
 
 # GPU-side allocator for Vulkan by AMD
 CPMAddPackage(


### PR DESCRIPTION
This PR adds support for unsized dynamic arrays in etna.

1. When we parse reflection info into a descriptor set layout, we now handle the case when dimensions are SPV_REFLECT_ARRAY_DIM_RUNTIME (i. e. 0). In this case, we set a special flag on DescriptorSetInfo (hasDynDescriptorArray) that indicates that this dset has a bindless array. This is only allowed for the last used binding in the set -- if it is not the last, we validate it (we also validate in on merging infos now)

2. Now in DescriptorSetInfo we store binding flags along with bindings themselves. They are not tweakable to the user, however for the dynamic array we set 'partial write' and 'variable count' flags. These flags are applied on dset layout creation. For variable dset count we set cap equal to the pool size for this dset type. 

3.  Pulled out dset allocation to separate function. In that function in the case dynamic array is used added a vk::DescriptorSetVariableDescriptorCountAllocateInfo filling to allocate as many descriptors for it, as bindings that were passed with the given binding index.

4. On descriptor write (in validation) only validated unbound slots in those bindings that were not created with 'partial write' flag (allow_unbound_slots still exists an removes this validation entirely, for people who need 'fake' bindless with static arrays) 

Cmake change because of:

```
CMake Warning (dev) at /home/hhf232/.local/lib/python3.10/site-packages/cmake/data/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:450 (message):
  `find_package()` specify a version range but the module Vulkan does not
  support this capability.  Only the lower endpoint of the range will be
  used.
Call Stack (most recent call first):
  /home/hhf232/.local/lib/python3.10/site-packages/cmake/data/share/cmake-3.31/Modules/FindVulkan.cmake:595 (find_package_handle_standard_args)
  /home/hhf232/Study/graph/etna/thirdparty.cmake:4 (find_package)
  /home/hhf232/Study/graph/etna/CMakeLists.txt:25 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
