### PR TITLE
bump some workflow repos

### DIFF
--- a/.github/workflows/comment-lint-results.yaml
+++ b/.github/workflows/comment-lint-results.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ZedThree/clang-tidy-review/post@v0.14.0 # v0.17 is buggy
+      - uses: ZedThree/clang-tidy-review/post@v0.20.1
         with:
           lgtm_comment_body: 'А я всегда говорил, нормально делай — нормально будет! 👍'
           annotations: false

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -25,9 +25,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Prepare Vulkan SDK
-      uses: humbletim/setup-vulkan-sdk@v1.2.0
+      uses: humbletim/setup-vulkan-sdk@v1.2.1
       with:
-        vulkan-query-version: 1.3.275.0
+        vulkan-query-version: 1.3.296.0
         vulkan-components: Vulkan-Headers, Vulkan-Loader
         vulkan-use-cache: true
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,9 +18,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Prepare Vulkan SDK
-      uses: humbletim/setup-vulkan-sdk@v1.2.0
+      uses: humbletim/setup-vulkan-sdk@v1.2.1
       with:
-        vulkan-query-version: 1.3.275.0
+        vulkan-query-version: 1.3.296.0
         vulkan-components: Vulkan-Headers, Vulkan-Loader
         vulkan-use-cache: true
 


### PR DESCRIPTION
- updated VulkanSDK for linux and win to same version as lint
- updated clang-tidy-review/post (idk how it worked until today)