### PR TITLE
use a separate semaphore for each swapchain image in present

### DIFF
--- a/etna/include/etna/PerFrameCmdMgr.hpp
+++ b/etna/include/etna/PerFrameCmdMgr.hpp
@@ -43,10 +43,14 @@ public:
    * write to color attachments only after the `after` semaphore is signaled.
    * Intended to be used with a semaphore that signals availability of the
    * swap chain image used in the buffer (see etna::Window::acquireNext).
-   * Returns a semaphore that is signaled when GPU has done executing the buffer,
-   * which is intended to be used for presenting the swap chain image (see etna::Window::present).
+   * Consumes a semaphore that is signaled when GPU has done executing the buffer,
+   * which is intended to be used for presenting the swap chain image (see etna::Window::present),
+   * and returns it (possibly renamed). It is rvalue, because semaphore must be signaled once.
    */
-  vk::Semaphore submit(vk::CommandBuffer what, vk::Semaphore write_attachments_after);
+  [[nodiscard]] vk::Semaphore submit(
+    vk::CommandBuffer what,
+    vk::Semaphore write_attachments_after,
+    vk::Semaphore&& use_result_after);
 
 private:
   vk::Device device;
@@ -55,9 +59,6 @@ private:
   vk::UniqueCommandPool pool;
   GpuSharedResource<vk::UniqueFence> commandsComplete;
   GpuSharedResource<bool> commandsSubmitted;
-
-  // NOTE: semaphores are GPU-only resources, no need to multi-buffer them.
-  vk::UniqueSemaphore gpuDone;
 
   std::optional<GpuSharedResource<vk::UniqueCommandBuffer>> buffers;
 };

--- a/etna/include/etna/Window.hpp
+++ b/etna/include/etna/Window.hpp
@@ -40,6 +40,7 @@ public:
     vk::Image image;
     vk::ImageView view;
     vk::Semaphore available;
+    vk::Semaphore readyForPresent;
   };
 
   /**
@@ -116,6 +117,7 @@ private:
     // Now, we don't really know which image will be acquired next, so we have no choice
     // but to have a dedicated ring buffer of semaphores of the same size as the swapchain.
     std::vector<vk::UniqueSemaphore> imageAvailable;
+    std::vector<vk::UniqueSemaphore> imageReadyForPresent;
     std::size_t presentCounter = 0;
   };
 


### PR DESCRIPTION
- Moved readyForPresent (aka gpuDone) into Window
- PerFrameCmdMgr now uses two semaphores for wait and signal, respectively. I use rvalue for the signal sem, because it should be clear that it can be signaled once. It can also be used for renaming, e.g. it will be “readyForPresent” when “gpuDone” or something like that.