### PR TITLE
Added PersistentDescriptorSet::updateBindings

### DIFF
--- a/etna/include/etna/BindingItems.hpp
+++ b/etna/include/etna/BindingItems.hpp
@@ -13,13 +13,13 @@ class Image;
 
 struct BufferBinding
 {
-  const Buffer& buffer;
+  const Buffer* buffer;
   vk::DescriptorBufferInfo descriptor_info;
 };
 
 struct ImageBinding
 {
-  const Image& image;
+  const Image* image;
   vk::DescriptorImageInfo descriptor_info;
 };
 

--- a/etna/source/Buffer.cpp
+++ b/etna/source/Buffer.cpp
@@ -112,7 +112,7 @@ void Buffer::unmap()
 
 BufferBinding Buffer::genBinding(vk::DeviceSize offset, vk::DeviceSize range) const
 {
-  return BufferBinding{*this, vk::DescriptorBufferInfo{get(), offset, range}};
+  return BufferBinding{this, vk::DescriptorBufferInfo{get(), offset, range}};
 }
 
 } // namespace etna

--- a/etna/source/Etna.cpp
+++ b/etna/source/Etna.cpp
@@ -75,15 +75,16 @@ DescriptorSet create_descriptor_set(
   BarrierBehavior behavior)
 {
   auto set = gContext->getDescriptorPool().allocateSet(layout, bindings, command_buffer, behavior);
-  write_set(set);
+  write_set(set, set.getBindings());
   return set;
 }
 
 PersistentDescriptorSet create_persistent_descriptor_set(
   DescriptorLayoutId layout, std::vector<Binding> bindings, bool allow_unbound_slots)
 {
-  auto set = gContext->getPersistentDescriptorPool().allocateSet(layout, bindings);
-  write_set(set, allow_unbound_slots);
+  auto set =
+    gContext->getPersistentDescriptorPool().allocateSet(layout, bindings, allow_unbound_slots);
+  write_set(set, set.getBindings(), allow_unbound_slots);
   return set;
 }
 

--- a/etna/source/Image.cpp
+++ b/etna/source/Image.cpp
@@ -178,7 +178,7 @@ vk::ImageView Image::getView(Image::ViewParams params) const
 
 ImageBinding Image::genBinding(vk::Sampler sampler, vk::ImageLayout layout, ViewParams params) const
 {
-  return ImageBinding{*this, vk::DescriptorImageInfo{sampler, getView(params), layout}};
+  return ImageBinding{this, vk::DescriptorImageInfo{sampler, getView(params), layout}};
 }
 
 } // namespace etna


### PR DESCRIPTION
This method shall allow bindless streaming, as before etna had ho way of updating a dset after creation. Only done for persistent dsets, as dynamic dsets live one frame and can just be created with everything at once.

To allow this, also changed binding structures to have pointers instead of refs (I believe it is not a good practice to have references as fields, as it silently makes the structure pinned in memory) to allow bindings vector modifications, and updated the 'write_set' function to allow generating writes only for some of the bindings.