### PR TITLE
buffer: do not call unmap in reset

### DIFF
--- a/etna/source/BlockingTransferHelper.cpp
+++ b/etna/source/BlockingTransferHelper.cpp
@@ -21,7 +21,6 @@ BlockingTransferHelper::BlockingTransferHelper(CreateInfo info)
       .name = "BlockingTransferHelper::stagingBuffer",
     })}
 {
-  stagingBuffer.map();
 }
 
 void BlockingTransferHelper::uploadBuffer(

--- a/etna/source/Buffer.cpp
+++ b/etna/source/Buffer.cpp
@@ -45,10 +45,8 @@ Buffer::Buffer(VmaAllocator alloc, CreateInfo info)
     vk::to_string(static_cast<vk::Result>(retcode)));
   buffer = vk::Buffer(buf);
 
-  // make map() forbidden for the user if allocationCreate has VMA_ALLOCATION_CREATE_MAPPED_BIT
-  if ((info.allocationCreate & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0u)
-    mapped = map();
-
+  // make map() optional if allocationCreate has VMA_ALLOCATION_CREATE_MAPPED_BIT
+  mapped = reinterpret_cast<std::byte*>(allocInfo.pMappedData);
   ETNA_VERIFY(mapped == nullptr || info.allocationCreate & VMA_ALLOCATION_CREATE_MAPPED_BIT);
 
   etna::set_debug_name(buffer, info.name.data());
@@ -99,7 +97,6 @@ void Buffer::reset()
 
 std::byte* Buffer::map()
 {
-  ETNA_VERIFY(mapped == nullptr);
   void* result;
 
   // I can't think of a use case where failing to do a mapping

--- a/etna/source/Buffer.cpp
+++ b/etna/source/Buffer.cpp
@@ -45,7 +45,6 @@ Buffer::Buffer(VmaAllocator alloc, CreateInfo info)
     vk::to_string(static_cast<vk::Result>(retcode)));
   buffer = vk::Buffer(buf);
 
-  // make map() optional if allocationCreate has VMA_ALLOCATION_CREATE_MAPPED_BIT
   mapped = reinterpret_cast<std::byte*>(allocInfo.pMappedData);
   ETNA_VERIFY(mapped == nullptr || info.allocationCreate & VMA_ALLOCATION_CREATE_MAPPED_BIT);
 
@@ -86,9 +85,6 @@ void Buffer::reset()
   if (!buffer)
     return;
 
-  if (mapped != nullptr)
-    unmap();
-
   vmaDestroyBuffer(allocator, VkBuffer(buffer), allocation);
   allocator = {};
   allocation = {};
@@ -97,6 +93,7 @@ void Buffer::reset()
 
 std::byte* Buffer::map()
 {
+  ETNA_VERIFY(mapped == nullptr);
   void* result;
 
   // I can't think of a use case where failing to do a mapping

--- a/etna/source/Etna.cpp
+++ b/etna/source/Etna.cpp
@@ -102,9 +102,7 @@ Image create_image_from_bytes(Image::CreateInfo info, vk::CommandBuffer cmd_buf,
     .name = "tmp_staging_buf",
   });
 
-  auto* mappedMem = stagingBuf.map();
-  std::memcpy(mappedMem, data, fullSize);
-  stagingBuf.unmap();
+  std::memcpy(stagingBuf.data(), data, fullSize);
 
   ETNA_CHECK_VK_RESULT(cmd_buf.begin(vk::CommandBufferBeginInfo{
     .flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit,

--- a/etna/source/PerFrameTransferHelper.cpp
+++ b/etna/source/PerFrameTransferHelper.cpp
@@ -63,7 +63,6 @@ PerFrameTransferHelper::PerFrameTransferHelper(CreateInfo info)
     stagingSize <= MAX_STAGING_SIZE,
     "PerFrameTransferHelper: total staging size can not exceed {} * multibuffering.",
     MAX_STAGING_SIZE);
-  stagingBuffer.iterate([](auto& buf) { buf.map(); });
 }
 
 void PerFrameTransferHelper::UploadProcessor::finish()


### PR DESCRIPTION
The reverted commit was wrong, because it makes VMA_ALLOCATION_CREATE_MAPPED_BIT useless.
Instead, do not call map/unmap if VMA_ALLOCATION_CREATE_MAPPED_BIT is used. 
You must explicitly call the unmap if the buffer is mapped without the VMA_ALLOCATION_CREATE_MAPPED_BIT flag (since you have already called map yourself)