### PR TITLE
Fixed barrier generation for attachments

### DIFF
--- a/etna/source/RenderTargetStates.cpp
+++ b/etna/source/RenderTargetStates.cpp
@@ -43,7 +43,11 @@ RenderTargetState::RenderTargetState(
     attachmentInfos[i].clearValue = color_attachments[i].clearColorValue;
 
     etna::get_context().getResourceTracker().setColorTarget(
-      commandBuffer, color_attachments[i].image, behavior);
+      commandBuffer,
+      color_attachments[i].image,
+      color_attachments[i].loadOp == vk::AttachmentLoadOp::eLoad,
+      color_attachments[i].storeOp == vk::AttachmentStoreOp::eStore,
+      behavior);
 
     if (color_attachments[i].resolveImage)
     {
@@ -90,6 +94,8 @@ RenderTargetState::RenderTargetState(
       commandBuffer,
       depth_attachment.image,
       vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil,
+      depth_attachment.loadOp == vk::AttachmentLoadOp::eLoad,
+      depth_attachment.storeOp == vk::AttachmentStoreOp::eStore,
       behavior);
 
     if (depth_attachment.resolveImage && stencil_attachment.resolveImage)
@@ -109,6 +115,8 @@ RenderTargetState::RenderTargetState(
         commandBuffer,
         depth_attachment.image,
         depth_attachment.imageAspect.value_or(vk::ImageAspectFlagBits::eDepth),
+        depth_attachment.loadOp == vk::AttachmentLoadOp::eLoad,
+        depth_attachment.storeOp == vk::AttachmentStoreOp::eStore,
         behavior);
 
       if (depth_attachment.resolveImage)
@@ -127,6 +135,8 @@ RenderTargetState::RenderTargetState(
         commandBuffer,
         stencil_attachment.image,
         stencil_attachment.imageAspect.value_or(vk::ImageAspectFlagBits::eStencil),
+        stencil_attachment.loadOp == vk::AttachmentLoadOp::eLoad,
+        stencil_attachment.storeOp == vk::AttachmentStoreOp::eStore,
         behavior);
 
       if (stencil_attachment.resolveImage)

--- a/etna/source/StateTracking.cpp
+++ b/etna/source/StateTracking.cpp
@@ -120,15 +120,20 @@ void ResourceStates::flushBarriers(vk::CommandBuffer com_buf)
 }
 
 void ResourceStates::setColorTarget(
-  vk::CommandBuffer com_buffer, vk::Image image, BarrierBehavior behavior)
+  vk::CommandBuffer com_buffer, vk::Image image, bool read, bool write, BarrierBehavior behavior)
 {
   if (get_context().shouldGenerateBarriersWhen(behavior))
   {
+    vk::AccessFlags2 accessFlags;
+    if (read)
+      accessFlags |= vk::AccessFlagBits2::eColorAttachmentRead;
+    if (write)
+      accessFlags |= vk::AccessFlagBits2::eColorAttachmentWrite;
     setTextureState(
       com_buffer,
       image,
       vk::PipelineStageFlagBits2::eColorAttachmentOutput,
-      vk::AccessFlagBits2::eColorAttachmentWrite,
+      accessFlags,
       vk::ImageLayout::eColorAttachmentOptimal,
       vk::ImageAspectFlagBits::eColor);
   }
@@ -138,16 +143,23 @@ void ResourceStates::setDepthStencilTarget(
   vk::CommandBuffer com_buffer,
   vk::Image image,
   vk::ImageAspectFlags aspect_flags,
+  bool read,
+  bool write,
   BarrierBehavior behavior)
 {
   if (get_context().shouldGenerateBarriersWhen(behavior))
   {
+    vk::AccessFlags2 accessFlags;
+    if (read)
+      accessFlags |= vk::AccessFlagBits2::eDepthStencilAttachmentRead;
+    if (write)
+      accessFlags |= vk::AccessFlagBits2::eDepthStencilAttachmentWrite;
     setTextureState(
       com_buffer,
       image,
       vk::PipelineStageFlagBits2::eEarlyFragmentTests |
         vk::PipelineStageFlagBits2::eLateFragmentTests,
-      vk::AccessFlagBits2::eDepthStencilAttachmentWrite,
+      accessFlags,
       vk::ImageLayout::eDepthStencilAttachmentOptimal,
       aspect_flags);
   }

--- a/etna/source/StateTracking.hpp
+++ b/etna/source/StateTracking.hpp
@@ -60,11 +60,15 @@ public:
   void setColorTarget(
     vk::CommandBuffer com_buffer,
     vk::Image image,
+    bool read,
+    bool write,
     BarrierBehavior behavior = BarrierBehavior::eDefault);
   void setDepthStencilTarget(
     vk::CommandBuffer com_buffer,
     vk::Image image,
     vk::ImageAspectFlags aspect_flags,
+    bool read,
+    bool write,
     BarrierBehavior behavior = BarrierBehavior::eDefault);
   void setResolveTarget(
     vk::CommandBuffer com_buffer,


### PR DESCRIPTION
Added missing read access when loadOp is vk::AttachmentLoadOp::eLoad -- we also need it in the barrier if we read prev values. Also removed unnecessary write access when store op is not 'store'.